### PR TITLE
Maintain order of Profiling Data state-groups

### DIFF
--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -91,15 +91,9 @@ namespace TuneUp
             {
                 state = value;
                 RaisePropertyChanged(nameof(State));
-                RaisePropertyChanged(nameof(StateValue));
             }
         }
         private ProfiledNodeState state;
-
-        /// <summary>
-        /// The current profiling state of this node as an integer value
-        /// </summary>
-        public int StateValue => (int)State;
 
         internal NodeModel NodeModel { get; set; }
 

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -4,7 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:TuneUp"
-             mc:Ignorable="d" 
+        xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+        mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"
             Width="500" Height="100">
     
@@ -74,6 +75,14 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
+            <CollectionViewSource Source="{Binding ProfiledNodes}" x:Key="ProfiledNodesCollection2">
+                <CollectionViewSource.GroupDescriptions>
+                    <PropertyGroupDescription PropertyName="State" />
+                </CollectionViewSource.GroupDescriptions>
+                <CollectionViewSource.SortDescriptions>
+                    <componentmodel:SortDescription PropertyName="State" Direction="Descending"/>
+                </CollectionViewSource.SortDescriptions>
+            </CollectionViewSource>
         </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -102,7 +111,7 @@
             <DataGrid 
             x:Name="NodeAnalysisTable" 
             Grid.Row="1"
-            ItemsSource="{Binding Path=ProfiledNodesCollection}"
+            ItemsSource="{Binding Path=ProfiledNodesCollection.View}"
             Style="{StaticResource DataGridStyle1}"
             GridLinesVisibility="Vertical"
             VerticalGridLinesBrush="#555555"

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -4,8 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:TuneUp"
-        xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
-        mc:Ignorable="d" 
+             xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+             mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"
             Width="500" Height="100">
     
@@ -75,14 +75,6 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <CollectionViewSource Source="{Binding ProfiledNodes}" x:Key="ProfiledNodesCollection2">
-                <CollectionViewSource.GroupDescriptions>
-                    <PropertyGroupDescription PropertyName="State" />
-                </CollectionViewSource.GroupDescriptions>
-                <CollectionViewSource.SortDescriptions>
-                    <componentmodel:SortDescription PropertyName="State" Direction="Descending"/>
-                </CollectionViewSource.SortDescriptions>
-            </CollectionViewSource>
         </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -7,10 +7,8 @@ using System.Windows.Controls;
 using Dynamo.Extensions;
 using Dynamo.Models;
 using Dynamo.Utilities;
-using Dynamo.ViewModels;
 using Dynamo.Wpf.Extensions;
 using Dynamo.Graph.Nodes;
-using System.Reflection;
 
 namespace TuneUp
 {

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -152,9 +152,8 @@ namespace TuneUp
             ProfiledNodesCollection = new CollectionViewSource();
             ProfiledNodesCollection.Source = ProfiledNodes;
 
-            ProfiledNodesCollection.GroupDescriptions.Add(new PropertyGroupDescription("State"));
-            ProfiledNodesCollection.SortDescriptions.Add(new SortDescription("State", ListSortDirection.Ascending));
-            ProfiledNodesCollection.LiveSortingProperties.Add("State");
+            ProfiledNodesCollection.GroupDescriptions.Add(new PropertyGroupDescription(nameof(ProfiledNodeViewModel.State)));
+            ProfiledNodesCollection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.State), ListSortDirection.Ascending));
             ProfiledNodesCollection.View.Refresh();
 
             RaisePropertyChanged(nameof(ProfiledNodesCollection));
@@ -225,7 +224,7 @@ namespace TuneUp
             ProfiledNodesCollection.Dispatcher.Invoke(() =>
             {
                 ProfiledNodesCollection.SortDescriptions.Clear();
-                ProfiledNodesCollection.SortDescriptions.Add(new SortDescription("State", ListSortDirection.Ascending));
+                ProfiledNodesCollection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.State), ListSortDirection.Ascending));
                 ProfiledNodesCollection.View.Refresh();
             });
             

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -141,7 +141,7 @@ namespace TuneUp
             {
                 return;
             }
-            ProfiledNodes = new ObservableCollection<ProfiledNodeViewModel>();
+            ProfiledNodes.Clear();
             foreach (var node in CurrentWorkspace.Nodes)
             {
                 var profiledNode = new ProfiledNodeViewModel(node);


### PR DESCRIPTION
This PR updates how grouping and sorting is handled for ProfiledNodesCollection. Previously, groups (such as `ExecutedOnCurrentRun` or `NotExecuted`) we're displayed in no particular order in the TuneUp window. Now they will maintain the order defined in the [ProfiledNodeState enum](https://github.com/DynamoDS/TuneUp/blob/master/TuneUp/TuneUpWindowViewModel.cs#L18-L23), with `ExecutedOnCurrentRun` (most relevant data) at the top after each graph execution.

<img width="376" alt="TuneUpGroups" src="https://user-images.githubusercontent.com/11542519/69482689-84391d80-0dec-11ea-8b9f-1b63a5a01022.PNG">

FYI @mjkkirschner @QilongTang 