### PR TITLE
Null Reference Crashes

### DIFF
--- a/TuneUp/TuneUp.csproj
+++ b/TuneUp/TuneUp.csproj
@@ -64,17 +64,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DynamoVisualProgramming.Core">
-      <Version>2.5.0-beta6246</Version>
+      <Version>2.5.0.7186</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.DynamoServices">
-      <Version>2.5.0-beta6246</Version>
+      <Version>2.5.0.7186</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.WpfUILibrary">
-      <Version>2.5.0-beta6246</Version>
+      <Version>2.5.0.7186</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -102,7 +102,7 @@ namespace TuneUp
         /// <summary>
         /// Collection of profiling data for nodes in the current workspace
         /// </summary>
-        public ObservableCollection<ProfiledNodeViewModel> ProfiledNodes { get; set; }
+        public ObservableCollection<ProfiledNodeViewModel> ProfiledNodes { get; set; } = new ObservableCollection<ProfiledNodeViewModel>();
 
         /// <summary>
         /// Collection of profiling data for nodes in the current workspace.
@@ -154,7 +154,8 @@ namespace TuneUp
 
             ProfiledNodesCollection.GroupDescriptions.Add(new PropertyGroupDescription(nameof(ProfiledNodeViewModel.State)));
             ProfiledNodesCollection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.State), ListSortDirection.Ascending));
-            ProfiledNodesCollection.View.Refresh();
+            if (ProfiledNodesCollection.View != null)
+                ProfiledNodesCollection.View.Refresh();
 
             RaisePropertyChanged(nameof(ProfiledNodesCollection));
             RaisePropertyChanged(nameof(ProfiledNodes));
@@ -225,7 +226,8 @@ namespace TuneUp
             {
                 ProfiledNodesCollection.SortDescriptions.Clear();
                 ProfiledNodesCollection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.State), ListSortDirection.Ascending));
-                ProfiledNodesCollection.View.Refresh();
+                if (ProfiledNodesCollection.View != null)
+                    ProfiledNodesCollection.View.Refresh();
             });
             
         }


### PR DESCRIPTION
When Nora Li from Civil Team and I were setting up Tuneup for Civil Team to consume, we were getting constant crashes which all point to null object references when launching Dynamo with TuneUp. After some debugging, I found there are multiple places which could cause such crash. Here are the fixes worked on my local system and a screen shot from Nora.
![image](https://user-images.githubusercontent.com/3942418/71638638-047e5880-2ca0-11ea-9758-973304335162.png)
