### PR TITLE
Fix a Total Execution Time bug

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,5 +1,5 @@
-# Build Tuneup using latest VS and DotNET
-name: Tuneup-Build
+# Build TuneUp using latest VS and DotNET
+name: TuneUp-Build
 on: [push]
 jobs:
  build:
@@ -30,7 +30,7 @@ jobs:
            .\MSBuild.exe $Env:GITHUB_WORKSPACE\Dynamo\src\Dynamo.All.sln
     - name: Build TuneUp with DotNET
       run: |
-        echo "***Building Tuneup now following Dynamo build***"
+        echo "***Building TuneUp now following Dynamo build***"
         cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
            .\MSBuild.exe $Env:GITHUB_WORKSPACE\TuneUp\TuneUp.sln
     # look for TuneUp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/DynamoDS/TuneUp/workflows/Tuneup-Build/badge.svg)
+![](https://github.com/DynamoDS/TuneUp/workflows/TuneUp-Build/badge.svg)
 
 # TuneUp
 
@@ -14,11 +14,11 @@ Here is a mock up of the future design:
 Recommended build environment
 - VisualStudio 2019
 - .Net Framework 4.7 Developer Pack
-- Dynamo repository cloned and built on the same level of Tuneup repository
+- Dynamo repository cloned and built on the same level of TuneUp repository which means you should find your Dynamo repo folder and TuneUp under the same parent folder
 
 ## Known issues
-- Tuneup does not work with dyfs yet
-- Tuneup is required to work with Dynamo 2.5.0 or up because of dependency on certian API which only exists on newer version of Dynamo.
+- TuneUp does not work with dyfs yet
+- TuneUp is required to work with Dynamo 2.5.0 or up because of dependency on certian API which only exists on newer version of Dynamo.
 
 ## Testing
 
@@ -32,7 +32,7 @@ Please check out known issues before go on testing.
 - Remove `TuneUp` from your Dynamo packages folder if you have it installed from package manager (otherwise `TuneUp.dll` will get loaded twice)
 - Launch DynamoSandbox.exe make click `View-> Open Tune Up` and enjoy it while having graph runs
 
-### Running Tuneup Unit Tests
+### Running TuneUp Unit Tests
 - Install NUnit 2 Test Adapter from VisualStudio->Extensions->Manage Extensions->Online
 - Open Test Explorer from VIsualStudio->Test->Test Explorer. Now you should see a list of TuneUpTests
 - Click the target test to run or run them all

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -145,7 +145,7 @@ namespace TuneUp
         }
 
         /// <summary>
-        /// An alternative constructor which we can customize data for display in Tuneup datagrid
+        /// An alternative constructor which we can customize data for display in TuneUp datagrid
         /// </summary>
         /// <param name="name">row display name</param>
         /// <param name="exTimeSum">execution time in ms</param>

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -243,15 +243,7 @@ namespace TuneUp
 
         private void CurrentWorkspaceModel_EvaluationStarted(object sender, EventArgs e)
         {
-            RaisePropertyChanged(nameof(TotalGraphExecutiontime));
             IsRecomputeEnabled = false;
-            uiContext.Send(
-                x =>
-                {
-                    ProfiledNodes.Remove(CurrentExecutionTimeRow);
-                    ProfiledNodes.Remove(PreviousExecutionTimeRow);
-                }, null);
-
             foreach (var node in nodeDictionary.Values)
             {
                 // Reset Node Execution Order info
@@ -294,14 +286,15 @@ namespace TuneUp
         /// </summary>
         private void UpdateExecutionTime()
         {
-            // After each evaluation, manually update execution time column(s)
-            var totalSpanExecuted = new TimeSpan(ProfiledNodes.Where(n => n.WasExecutedOnLastRun).Sum(r => r.ExecutionTime.Ticks));
-            var totalSpanUnexecuted = new TimeSpan(ProfiledNodes.Where(n => !n.WasExecutedOnLastRun).Sum(r => r.ExecutionTime.Ticks));
-
-            // Add execution time back
+            // Reset execution time
             uiContext.Send(
                 x =>
                 {
+                    ProfiledNodes.Remove(CurrentExecutionTimeRow);
+                    ProfiledNodes.Remove(PreviousExecutionTimeRow);
+                    // After each evaluation, manually update execution time column(s)
+                    var totalSpanExecuted = new TimeSpan(ProfiledNodes.Where(n => n.WasExecutedOnLastRun).Sum(r => r.ExecutionTime.Ticks));
+                    var totalSpanUnexecuted = new TimeSpan(ProfiledNodes.Where(n => !n.WasExecutedOnLastRun).Sum(r => r.ExecutionTime.Ticks));
                     ProfiledNodes.Add(new ProfiledNodeViewModel(
                         CurrentExecutionString, totalSpanExecuted, ProfiledNodeState.ExecutedOnCurrentRun));
                     ProfiledNodes.Add(new ProfiledNodeViewModel(


### PR DESCRIPTION
1. Fix all the Tuneup instances in readme and code
2. Fix a bug that user may see multiple total execution time row in certain cases. e.g. when evaluation started event did not get triggered