### PR TITLE
Fix description and update to 1.0.7

### DIFF
--- a/TuneUp/manifests/pkg.json
+++ b/TuneUp/manifests/pkg.json
@@ -2,8 +2,8 @@
   "license": "",
   "file_hash": null,
   "name": "TuneUp",
-  "version": "1.0.6",
-  "description": "TuneUp is in beta and is a view extension for analyzing the performance of Dynamo graphs. TuneUp allows you to see overall graph execution time, per-node execution time, and other helpful information about what's happening under the hood, e.g. nodes run in the current execution v.s. nodes run in the previous execution (which are skipped this run for optimization/ caching). Read more here:https://dynamobim.org/tuneup-extension-explore-your-node-and-graph-execution-times/\r\nKnown issues:\r\n1. TuneUp does not work with .dyfs (custom nodes) yet.\r\n2. TuneUp binaries are not semantically versioned and are not intended to be built on top of as an API. Do not treat these binaries like DynamoCore.\r\n3. TuneUp requires Dynamo 2.5 or higher for access to new extension APIs.\r\n4. When user have TuneUp open, after switching workspace in Dynamo, the first graph run does not give execution time and nodes order.",
+  "version": "1.0.7",
+  "description": "*** THE TUNEUP EXTENSION USES NEW API FEATURES THAT ARE ONLY AVAILABLE IN DYNAMO VERSION 2.5 OR ABOVE ***\r\n\r\nTuneUp is in beta and is a view extension for analyzing the performance of Dynamo graphs. TuneUp allows you to see overall graph execution time, per-node execution time, and other helpful information about what's happening under the hood, e.g. nodes run in the current execution v.s. nodes run in the previous execution (which are skipped this run for optimization/ caching). Read more here: https://dynamobim.org/tuneup-extension-explore-your-node-and-graph-execution-times/ \r\n\r\nKnown issues:\r\n1. TuneUp does not work with .dyfs (custom nodes) yet.\r\n2.TuneUp binaries are not semantically versioned and are not intended to be built on top of as an API. Do not treat these binaries like DynamoCore.\r\n3. TuneUp requires Dynamo 2.5 or higher for access to new extension APIs.\r\n4. When user have TuneUp open, after switching workspace in Dynamo, the first graph run does not give execution time and nodes order.",
   "group": "",
   "keywords": [
     "profiler",


### PR DESCRIPTION
Opening the PR before publishing, just in case.

Took the description from published version 1.0.5 and added the `Read more here` part.

Also, I guess we need to publish a new version, so it's 1.0.7, right?