### PR TITLE
WIP -  adding callsite information and clear functionality to TuneUp

### DIFF
--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -130,6 +130,20 @@ namespace TuneUp
             }
         }
 
+        private string callsiteData;
+        /// <summary>
+        /// A string representing the serialized trace data contained in this callsite.
+        /// </summary>
+        public string CallSiteData
+        {
+            get { return callsiteData; }
+            set
+            {
+                callsiteData = value;
+                RaisePropertyChanged(nameof(CallSiteData));
+            }
+        }
+
         internal NodeModel NodeModel { get; set; }
 
         #endregion

--- a/TuneUp/TuneUp.csproj
+++ b/TuneUp/TuneUp.csproj
@@ -93,7 +93,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <DynamoVersion>2.5</DynamoVersion>
+    <DynamoVersion>2.11</DynamoVersion>
     <PackageName>TuneUp</PackageName>
     <PackageFolder>$(ProjectDir)dist\$(PackageName)\</PackageFolder>
     <BinFolder>$(PackageFolder)bin\</BinFolder>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -98,6 +98,15 @@
                 Padding="5,2,5,2">
                 Force Re-execute
             </Button>
+            <Button
+                Name="ClearTraceButton"
+                Width="Auto"
+                Height="Auto"
+                Margin="2,1,1,10"
+                Click="ClearTrace_Click"
+                Padding="5,2,5,2">
+                Clear Trace/ElementBinding Data
+            </Button>
             <Label Foreground="White">Total Graph Execution Time: </Label>
             <Label Foreground="White"
                    Name="TotalGraphExecutiontimeLabel"
@@ -184,6 +193,22 @@
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
+                                <Setter Property="Margin" Value="10,0,10,0"/>
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+
+                    <!-- callsite data -->
+                    <DataGridTextColumn 
+                    Header="callsite data" 
+                    Binding="{Binding CallSiteData}" 
+                    Foreground="#aaaaaa" 
+                    IsReadOnly="True" 
+                    Width="Auto">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock" >
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                                <Setter Property="TextBlock.TextWrapping" Value="Wrap" />
                                 <Setter Property="Margin" Value="10,0,10,0"/>
                             </Style>
                         </DataGridTextColumn.ElementStyle>

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -4,8 +4,10 @@ using System.Windows;
 using System.Windows.Controls;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
+using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.Utilities;
+using Dynamo.ViewModels;
 using Dynamo.Wpf.Extensions;
 
 namespace TuneUp
@@ -89,6 +91,24 @@ namespace TuneUp
         private void RecomputeGraph_Click(object sender, RoutedEventArgs e)
         {
             (NodeAnalysisTable.DataContext as TuneUpWindowViewModel).ResetProfiling();
+        }
+
+        private void ClearTrace_Click(object sender, RoutedEventArgs e)
+        {
+            var engine = (viewLoadedParams.CurrentWorkspaceModel as HomeWorkspaceModel).EngineController;
+            var callsites = engine.LiveRunnerRuntimeCore.RuntimeData.GetCallsitesForNodes(
+                viewLoadedParams.CurrentWorkspaceModel.Nodes.Select(x => x.GUID),
+                engine.LiveRunnerCore.DSExecutable);
+
+            foreach (var kvp in callsites)
+            {
+                foreach (var callsite in kvp.Value)
+                {
+                    callsite.TraceData.Clear();
+                }
+            }
+            (NodeAnalysisTable.DataContext as TuneUpWindowViewModel).GetCallSiteDataForCurrentNodesAndUpdateView();
+
         }
     }
 }

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -260,7 +260,22 @@ namespace TuneUp
                 ProfiledNodesCollection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.ExecutionOrderNumber), ListSortDirection.Descending));
                 if (ProfiledNodesCollection.View != null)
                     ProfiledNodesCollection.View.Refresh();
+                GetCallSiteDataForCurrentNodesAndUpdateView();
             });
+        }
+
+        internal void GetCallSiteDataForCurrentNodesAndUpdateView()
+        {
+            foreach (var item in ProfiledNodes)
+            {
+                if (item.NodeModel != null)
+                {
+                    var engine = (viewLoadedParams.CurrentWorkspaceModel as HomeWorkspaceModel).EngineController;
+                    var callsites = engine.LiveRunnerRuntimeCore.RuntimeData.GetCallsitesForNodes(new Guid[] { (item.NodeModel.GUID) }, engine.LiveRunnerCore.DSExecutable).FirstOrDefault();
+                    item.CallSiteData = String.Join(Environment.NewLine, callsites.Value.Select(x => x.GetTraceDataToSave()));
+                }
+
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
A small experiment in adding callsite info to tuneup

- add another column to tuneup to display serialized trace data.
- add a button to top level to delete all active trace data.

### TODO
 - [ ] callsite display should be more useful - base64 encoded is not useful.
- [ ] callsite data should be collapsed by default.
- [ ] tests