### PR TITLE
TuneUp menu item should be under Extensions menu.

### DIFF
--- a/TuneUp/TuneUp.csproj
+++ b/TuneUp/TuneUp.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TuneUp</RootNamespace>
     <AssemblyName>TuneUp</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files\Dynamo\Dynamo Core\2\DynamoSandbox.exe</StartProgram>
     <FileAlignment>512</FileAlignment>
@@ -65,17 +65,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DynamoVisualProgramming.Core">
-      <Version>2.5.0.7432</Version>
+      <Version>2.12.0.5650</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.DynamoServices">
-      <Version>2.5.0.7432</Version>
+      <Version>2.12.0.5650</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.WpfUILibrary">
-      <Version>2.5.0.7432</Version>
+      <Version>2.12.0.5650</Version>
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -93,7 +93,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <DynamoVersion>2.5</DynamoVersion>
+    <DynamoVersion>2.12</DynamoVersion>
     <PackageName>TuneUp</PackageName>
     <PackageFolder>$(ProjectDir)dist\$(PackageName)\</PackageFolder>
     <BinFolder>$(PackageFolder)bin\</BinFolder>

--- a/TuneUp/TuneUpViewExtension.cs
+++ b/TuneUp/TuneUpViewExtension.cs
@@ -26,6 +26,7 @@ namespace TuneUp
 
         public override void Loaded(ViewLoadedParams p)
         {
+            // Use dynamic object type of ViewLoadedParams to dynamically call its methods.
             dynamic dp = (dynamic) p;
             ViewModel = new TuneUpWindowViewModel(p);
 
@@ -51,6 +52,7 @@ namespace TuneUp
                 }
             };
 
+            // Add this view extension's menu item to the Extensions tab or View tab accordingly.
             var dynamoMenuItems = p.dynamoMenu.Items.OfType<MenuItem>();
             var extensionsMenuItem = dynamoMenuItems.Where(item => item.Header.ToString() == "_Extensions");
 

--- a/TuneUp/TuneUpViewExtension.cs
+++ b/TuneUp/TuneUpViewExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Linq;
 using System.Windows.Controls;
 using Dynamo.Wpf.Extensions;
 
@@ -26,7 +26,9 @@ namespace TuneUp
 
         public override void Loaded(ViewLoadedParams p)
         {
+            dynamic dp = (dynamic) p;
             ViewModel = new TuneUpWindowViewModel(p);
+
             TuneUpView = new TuneUpWindow(p, UniqueId)
             {
                 // Set the data context for the main grid in the window.
@@ -47,9 +49,19 @@ namespace TuneUp
                 {
                     p.CloseExtensioninInSideBar(this);
                 }
-
             };
-            p.AddExtensionMenuItem(TuneUpMenuItem);
+
+            var dynamoMenuItems = p.dynamoMenu.Items.OfType<MenuItem>();
+            var extensionsMenuItem = dynamoMenuItems.Where(item => item.Header.ToString() == "_Extensions");
+
+            if (extensionsMenuItem.Count() > 0)
+            {
+                dp.AddExtensionMenuItem(TuneUpMenuItem);
+            }
+            else
+            {
+                dp.AddMenuItem(MenuBarType.View, TuneUpMenuItem);
+            }
         }
 
         /// <summary>

--- a/TuneUp/TuneUpViewExtension.cs
+++ b/TuneUp/TuneUpViewExtension.cs
@@ -9,22 +9,22 @@ namespace TuneUp
     /// which allows Dynamo users to analyze the performance of graphs
     /// and diagnose bottlenecks and problem areas.
     /// </summary>
-    public class TuneUpViewExtension : IViewExtension
+    public class TuneUpViewExtension : ViewExtensionBase, IViewExtension
     {
         internal MenuItem TuneUpMenuItem;
         private TuneUpWindow TuneUpView;
         internal TuneUpWindowViewModel ViewModel;
 
-        public void Dispose()
+        public override void Dispose()
         {
             TuneUpView.Dispose();
         }
 
-        public void Startup(ViewStartupParams p)
+        public override void Startup(ViewStartupParams p)
         {
         }
 
-        public void Loaded(ViewLoadedParams p)
+        public override void Loaded(ViewLoadedParams p)
         {
             ViewModel = new TuneUpWindowViewModel(p);
             TuneUpView = new TuneUpWindow(p, UniqueId)
@@ -49,7 +49,7 @@ namespace TuneUp
                 }
 
             };
-            p.AddMenuItem(MenuBarType.View, TuneUpMenuItem);
+            p.AddExtensionMenuItem(TuneUpMenuItem);
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace TuneUp
         /// <summary>
         /// ID for the TuneUp extension
         /// </summary>
-        public string UniqueId
+        public override string UniqueId
         {
             get
             {
@@ -74,11 +74,19 @@ namespace TuneUp
         /// <summary>
         /// Name of this extension
         /// </summary>
-        public string Name
+        public override string Name
         {
             get
             {
                 return "TuneUp";
+            }
+        }
+
+        public override void Closed()
+        {
+            if (this.TuneUpMenuItem != null)
+            {
+                this.TuneUpMenuItem.IsChecked = false;
             }
         }
     }

--- a/TuneUpTests/TuneUpTests.csproj
+++ b/TuneUpTests/TuneUpTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TuneUpTests</RootNamespace>
     <AssemblyName>TuneUpTests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
@@ -65,16 +65,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DynamoVisualProgramming.Core">
-      <Version>2.5.0.7432</Version>
+      <Version>2.12.0.5650</Version>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.DynamoServices">
-      <Version>2.5.0.7432</Version>
+      <Version>2.12.0.5650</Version>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.Tests">
-      <Version>2.5.0.7432</Version>
+      <Version>2.12.0.5650</Version>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary">
-      <Version>2.5.0.7432</Version>
+      <Version>2.12.0.5650</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>1.3.2</Version>


### PR DESCRIPTION
When TuneUp package is installed, "Show TuneUp" menu item should be present under the Extensions menu.

To use the AddExtensionMenuItem API from ViewLoadedParams class, the DynamoCore references are pointed to the Dynamo 2.12 version. The TargetFrameworkVersion is also set to v4.8.

<img width="523" alt="Screen Shot 2021-07-23 at 8 44 03 AM" src="https://user-images.githubusercontent.com/43763136/126788323-a8d38199-4bc3-4e5f-a105-8c3d9a9e4315.png">
