### PR TITLE
Update to .NET

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <FileAlignment>512</FileAlignment>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems> <!-- Disable default inclusion of all *.cs files to avoid duplicate compile item errors. -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo> <!-- Prevent generation of AssemblyInfo.cs to avoid duplicate attributes. -->
+    <EnableDefaultPageItems>false</EnableDefaultPageItems> <!-- Disable default inclusion of all *.xaml files to avoid duplicate page item errors. -->
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DynamoPackageVersion>3.2.1.5366</DynamoPackageVersion>
+    <MSTestVersion>1.3.2</MSTestVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>  
+</Project>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TuneUp is in `beta`.
 
 TuneUp is a view extension for analyzing the performance of Dynamo graphs. TuneUp allows you to see overall graph execution time, per-node execution time, and other helpful information about what's happening under the hood, e.g. nodes run in the current execution v.s. nodes run in the previous execution (which were skipped during the most recent graph run for optimization/ caching).
 
-Here is a short demo of how to utilize it as of now:
+Here is a short demo of how to utilize it as of now (now loading from the Extensions menu):
 ![TuneUp](design/gifs/TuneUpScroll.gif)
 
 Here is a mock up of the future design:
@@ -16,8 +16,8 @@ Here is a mock up of the future design:
 
 ### Recommended Build Environment
 
-- VisualStudio 2019
-- .Net Framework 4.7 Developer Pack
+- VisualStudio 2022 or later
+- .NET 8.0 Developer Pack
 - Dynamo repository cloned and built on the same level of TuneUp repository which means your Dynamo repo and TuneUp repo should exist under the same parent folder.
 
 ### Result Binaries
@@ -32,7 +32,7 @@ Under `TuneUp\dist\TuneUp`, there is a sample package wrapped up ready for publi
 
 - TuneUp does not work with .dyfs (custom nodes) yet.
 - TuneUp binaries are not semantically versioned and are not intended to be built on top of as an API. Do not treat these binaries like DynamoCore.
-- TuneUp requires Dynamo 2.5 or higher for access to new extension APIs.
+- TuneUp requires Dynamo 3.0 or higher for access to new extension APIs.
 - When user have TuneUp open, after switching workspace in Dynamo, the first graph run does not give execution time and nodes order.
 - Although it's not an issue by itself, TuneUp profiles the execution of graphs even if not showing on the extension bar.
 - In some cases TuneUp may calculate incorrect execution times for nodes, we cannot reproduce this consistently, if you see this occur and can reproduce it please file an issue!
@@ -43,7 +43,7 @@ Under `TuneUp\dist\TuneUp`, there is a sample package wrapped up ready for publi
 
 Please check out known issues before trying to setup testing.
 
-- Download DynamoCoreRuntime 2.5.0 (or higher) from [dynamobuilds.com](https://dynamobuilds.com/). Alternatively, you can build Dynamo from Dynamo repository and use the bin folder equivalently.
+- Download DynamoCoreRuntime 3.0.0 (or higher) from [dynamobuilds.com](https://dynamobuilds.com/). Alternatively, you can build Dynamo from Dynamo repository and use the bin folder equivalently.
 - Copy all contents of the DynamoCoreRuntime to `TuneUp\TuneUpTests\bin\Debug\`. If you are building Dynamo locally, copy all contents of Dynamo from `Dynamo/bin/AnyCPU/Debug` to `TuneUp\TuneUpTests\bin\Debug\`
 - Copy `TuneUp_ViewExtensionDefinition.xml` from `TuneUp\TuneUp\manifests\` to `TuneUp\TuneUpTests\bin\Debug\viewExtensions\`
 - Open the copied `TuneUp_ViewExtensionDefinition.xml` and change the assemply path to `..\TuneUp.dll`
@@ -52,6 +52,6 @@ Please check out known issues before trying to setup testing.
 
 ### Running TuneUp Unit Tests
 
-- Install NUnit 2 Test Adapter from VisualStudio->Extensions->Manage Extensions->Online.
+- Install NUnit3TestAdapter from VisualStudio->Extensions->Manage Extensions->Online.
 - Open Test Explorer from VisualStudio->Test->Test Explorer. Now you should see a list of TuneUpTests.
 - Click the target test to run or run them all.

--- a/TuneUp/TuneUp.csproj
+++ b/TuneUp/TuneUp.csproj
@@ -70,19 +70,23 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="DynamoVisualProgramming.Core" Version="3.0.0.7186">
-	  <ExcludeAssets>runtime</ExcludeAssets>
-      <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
-	</PackageReference>
-    <PackageReference Include="DynamoVisualProgramming.DynamoServices" Version="3.0.0.7186">
-      <ExcludeAssets>runtime</ExcludeAssets>
-      <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="DynamoVisualProgramming.WpfUILibrary" Version="3.0.0.7186">
-      <ExcludeAssets>runtime</ExcludeAssets>
-      <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+	  <PackageReference Include="DynamoVisualProgramming.Core" Version="3.2.1.5366">
+		  <ExcludeAssets>runtime</ExcludeAssets>
+		  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Include="DynamoVisualProgramming.Tests" Version="3.2.1.5366">
+		  <ExcludeAssets>runtime</ExcludeAssets>
+		  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Include="DynamoVisualProgramming.WpfUILibrary" Version="3.2.1.5366">
+		  <ExcludeAssets>runtime</ExcludeAssets>
+		  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
+	  </PackageReference>
+	  <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary" Version="3.2.1.5366">
+		  <ExcludeAssets>runtime</ExcludeAssets>
+		  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
+	  </PackageReference>
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>

--- a/TuneUp/TuneUp.csproj
+++ b/TuneUp/TuneUp.csproj
@@ -1,20 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Default properties for the project -->
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
-	<UseWPF>true</UseWPF>
     <RootNamespace>TuneUp</RootNamespace>
     <AssemblyName>TuneUp</AssemblyName>
     <OutputType>Library</OutputType>
     <StartAction>Program</StartAction>
-    <StartProgram>C:\Program Files\Dynamo\Dynamo Core\3\DynamoSandbox.exe</StartProgram>
-    <FileAlignment>512</FileAlignment>
-	<!-- Disable default inclusion of all *.cs files to avoid duplicate compile item errors. -->
+	<StartProgram>C:\Program Files\Dynamo\Dynamo Core\3.2\DynamoSandbox.exe</StartProgram>
 	<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-	<!-- Prevent generation of AssemblyInfo.cs to avoid duplicate attributes. -->
-	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<!-- Disable default inclusion of all *.xaml files to avoid duplicate page item errors. -->
-	<EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
+  <!-- Properties specific to Debug configuration -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -24,6 +19,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <!-- Properties specific to Release configuration -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -32,6 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <!-- References to other assemblies -->
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -46,6 +43,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
+  <!-- Source code files to be compiled -->
   <ItemGroup>
     <Compile Include="ProfiledNodeViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -55,32 +53,31 @@
       <DependentUpon>TuneUpWindow.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
+  <!-- XAML files to be compiled -->
   <ItemGroup>
     <Page Include="TuneUpWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
+  <!-- Package references -->
   <ItemGroup>
-	  <PackageReference Include="DynamoVisualProgramming.Core" Version="3.2.1.5366">
+	  <PackageReference Include="DynamoVisualProgramming.Core" Version="$(DynamoPackageVersion)">
 		  <ExcludeAssets>runtime</ExcludeAssets>
 		  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="DynamoVisualProgramming.Tests" Version="3.2.1.5366">
+	  <PackageReference Include="DynamoVisualProgramming.Tests" Version="$(DynamoPackageVersion)">
 		  <ExcludeAssets>runtime</ExcludeAssets>
 		  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="DynamoVisualProgramming.WpfUILibrary" Version="3.2.1.5366">
+	  <PackageReference Include="DynamoVisualProgramming.WpfUILibrary" Version="$(DynamoPackageVersion)">
 		  <ExcludeAssets>runtime</ExcludeAssets>
 		  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary" Version="3.2.1.5366">
+	  <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary" Version="$(DynamoPackageVersion)">
 		  <ExcludeAssets>runtime</ExcludeAssets>
 		  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
-	  </PackageReference>
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+	  </PackageReference>	
   </ItemGroup>
   <ItemGroup>
     <None Include="manifests\pkg.json" />
@@ -88,17 +85,19 @@
   </ItemGroup>
   <!-- Including Custom Properties, PreBuildEvent, and Import -->
   <PropertyGroup>
-    <DynamoVersion>2.12</DynamoVersion>
+    <DynamoVersion>3.2</DynamoVersion>
     <PackageName>TuneUp</PackageName>
     <PackageFolder>$(ProjectDir)dist\$(PackageName)\</PackageFolder>
     <BinFolder>$(PackageFolder)bin\</BinFolder>
     <ExtraFolder>$(PackageFolder)extra\</ExtraFolder>
     <DyfFolder>$(PackageFolder)dyf\</DyfFolder>
   </PropertyGroup>
+  <!-- Pre-build events -->
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
+  <!-- Post-build events to handle package deployment -->
   <Target Name="AfterBuild">
     <ItemGroup>
       <Dlls Include="$(OutDir)TuneUp.dll" />
@@ -115,6 +114,7 @@
     <MakeDir Directories="$(DyfFolder)" Condition="!Exists($(DyfFolder))" />
     <CallTarget Condition="'$(Configuration)' == 'Debug'" Targets="PackageDeploy" />
   </Target>
+  <!-- Target for package deployment -->
   <Target Name="PackageDeploy">
     <ItemGroup>
       <SourcePackage Include="$(PackageFolder)**\*" />

--- a/TuneUp/TuneUp.csproj
+++ b/TuneUp/TuneUp.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
+	<!-- Disable default inclusion of all *.cs files to avoid duplicate compile item errors. -->
 	<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>net8.0-windows</TargetFramework>
 	<UseWPF>true</UseWPF>
@@ -9,9 +10,11 @@
     <AssemblyName>TuneUp</AssemblyName>
     <OutputType>Library</OutputType>
     <StartAction>Program</StartAction>
-    <StartProgram>C:\Program Files\Dynamo\Dynamo Core\2\DynamoSandbox.exe</StartProgram>
+    <StartProgram>C:\Program Files\Dynamo\Dynamo Core\3\DynamoSandbox.exe</StartProgram>
     <FileAlignment>512</FileAlignment>
+	<!-- Prevent generation of AssemblyInfo.cs to avoid duplicate attributes. -->
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<!-- Disable default inclusion of all *.xaml files to avoid duplicate page item errors. -->
 	<EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
   
@@ -67,10 +70,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.Core" Version="3.0.0.7186">
-      <ExcludeAssets>runtime</ExcludeAssets>
+	<PackageReference Include="DynamoVisualProgramming.Core" Version="3.0.0.7186">
+	  <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+	</PackageReference>
     <PackageReference Include="DynamoVisualProgramming.DynamoServices" Version="3.0.0.7186">
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
@@ -79,6 +82,9 @@
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TuneUp/TuneUp.csproj
+++ b/TuneUp/TuneUp.csproj
@@ -1,23 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{6FF12D3A-025E-49A5-A773-D99AB82778A3}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+	<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TargetFramework>net8.0-windows</TargetFramework>
+	<UseWPF>true</UseWPF>
     <RootNamespace>TuneUp</RootNamespace>
     <AssemblyName>TuneUp</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <OutputType>Library</OutputType>
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files\Dynamo\Dynamo Core\2\DynamoSandbox.exe</StartProgram>
     <FileAlignment>512</FileAlignment>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <TargetFrameworkProfile />
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -26,7 +24,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -34,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -48,50 +48,45 @@
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="ProfiledNodeViewModel.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TuneUpViewExtension.cs" />
     <Compile Include="TuneUpWindowViewModel.cs" />
     <Compile Include="TuneUpWindow.xaml.cs">
       <DependentUpon>TuneUpWindow.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <Page Include="TuneUpWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.Core">
-      <Version>2.12.0.5650</Version>
+    <PackageReference Include="DynamoVisualProgramming.Core" Version="3.0.0.7186">
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="DynamoVisualProgramming.DynamoServices">
-      <Version>2.12.0.5650</Version>
+    <PackageReference Include="DynamoVisualProgramming.DynamoServices" Version="3.0.0.7186">
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="DynamoVisualProgramming.WpfUILibrary">
-      <Version>2.12.0.5650</Version>
+    <PackageReference Include="DynamoVisualProgramming.WpfUILibrary" Version="3.0.0.7186">
       <ExcludeAssets>runtime</ExcludeAssets>
       <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="manifests\pkg.json" />
     <None Include="manifests\TuneUp_ViewExtensionDefinition.xml" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
+  <!-- Including Custom Properties, PreBuildEvent, and Import -->
   <PropertyGroup>
     <DynamoVersion>2.12</DynamoVersion>
     <PackageName>TuneUp</PackageName>
@@ -104,6 +99,7 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
+
   <Target Name="AfterBuild">
     <ItemGroup>
       <Dlls Include="$(OutDir)TuneUp.dll" />
@@ -116,10 +112,11 @@
     <Copy SourceFiles="@(Xmls)" DestinationFolder="$(BinFolder)" />
     <Copy SourceFiles="@(ViewExtensionDefs)" DestinationFolder="$(ExtraFolder)" />
     <Copy SourceFiles="@(PackageJson)" DestinationFolder="$(PackageFolder)" />
-    <MakeDir Directories="$(ExtraFolder)" Condition="!Exists($(ExtraFolder))"/>
-    <MakeDir Directories="$(DyfFolder)" Condition="!Exists($(DyfFolder))"/>
+    <MakeDir Directories="$(ExtraFolder)" Condition="!Exists($(ExtraFolder))" />
+    <MakeDir Directories="$(DyfFolder)" Condition="!Exists($(DyfFolder))" />
     <CallTarget Condition="'$(Configuration)' == 'Debug'" Targets="PackageDeploy" />
   </Target>
+
   <Target Name="PackageDeploy">
     <ItemGroup>
       <SourcePackage Include="$(PackageFolder)**\*" />
@@ -135,7 +132,7 @@
     <Message Importance="high" Text="Dynamo Revit Package Folder = $(DynamoRevit)" />
     <Copy SourceFiles="@(SourcePackage)" Condition="Exists($(DynamoCore))" DestinationFolder="$(DynamoCore)\$(PackageName)\%(RecursiveDir)" />
     <Copy SourceFiles="@(SourcePackage)" Condition="Exists($(DynamoRevit))" DestinationFolder="$(DynamoRevit)\$(PackageName)\%(RecursiveDir)" />
-    <MakeDir Directories="$(PackageExtraFolder)" Condition="!Exists($(PackageExtraFolder))"/>
-    <MakeDir Directories="$(PackageDyfFolder)" Condition="!Exists($(PackageDyfFolder))"/>
+    <MakeDir Directories="$(PackageExtraFolder)" Condition="!Exists($(PackageExtraFolder))" />
+    <MakeDir Directories="$(PackageDyfFolder)" Condition="!Exists($(PackageDyfFolder))" />
   </Target>
 </Project>

--- a/TuneUp/TuneUp.csproj
+++ b/TuneUp/TuneUp.csproj
@@ -1,9 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<!-- Disable default inclusion of all *.cs files to avoid duplicate compile item errors. -->
-	<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>net8.0-windows</TargetFramework>
 	<UseWPF>true</UseWPF>
     <RootNamespace>TuneUp</RootNamespace>
@@ -12,12 +8,13 @@
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files\Dynamo\Dynamo Core\3\DynamoSandbox.exe</StartProgram>
     <FileAlignment>512</FileAlignment>
+	<!-- Disable default inclusion of all *.cs files to avoid duplicate compile item errors. -->
+	<EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 	<!-- Prevent generation of AssemblyInfo.cs to avoid duplicate attributes. -->
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<!-- Disable default inclusion of all *.xaml files to avoid duplicate page item errors. -->
 	<EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
-  
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -27,7 +24,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -36,7 +32,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -51,7 +46,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="ProfiledNodeViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -61,14 +55,12 @@
       <DependentUpon>TuneUpWindow.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <Page Include="TuneUpWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-
   <ItemGroup>
 	  <PackageReference Include="DynamoVisualProgramming.Core" Version="3.2.1.5366">
 		  <ExcludeAssets>runtime</ExcludeAssets>
@@ -90,12 +82,10 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="manifests\pkg.json" />
     <None Include="manifests\TuneUp_ViewExtensionDefinition.xml" />
   </ItemGroup>
-
   <!-- Including Custom Properties, PreBuildEvent, and Import -->
   <PropertyGroup>
     <DynamoVersion>2.12</DynamoVersion>
@@ -109,7 +99,6 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
-
   <Target Name="AfterBuild">
     <ItemGroup>
       <Dlls Include="$(OutDir)TuneUp.dll" />
@@ -126,7 +115,6 @@
     <MakeDir Directories="$(DyfFolder)" Condition="!Exists($(DyfFolder))" />
     <CallTarget Condition="'$(Configuration)' == 'Debug'" Targets="PackageDeploy" />
   </Target>
-
   <Target Name="PackageDeploy">
     <ItemGroup>
       <SourcePackage Include="$(PackageFolder)**\*" />

--- a/TuneUp/TuneUpViewExtension.cs
+++ b/TuneUp/TuneUpViewExtension.cs
@@ -54,7 +54,11 @@ namespace TuneUp
 
             // Add this view extension's menu item to the Extensions tab or View tab accordingly.
             var dynamoMenuItems = p.dynamoMenu.Items.OfType<MenuItem>();
-            var extensionsMenuItem = dynamoMenuItems.Where(item => item.Header.ToString() == "_Extensions");
+            // TODO: Investigate why TuneUpMenuItem is not added to the specified MenuItem
+            // When _Extensions is specified, TuneUpMenuItem goes to the View menu in Dynamo 3.0-
+            // and does not appear in Dynamo 3.1+.
+            // We need to specify _View for TuneUpMenuItem to be added to the Extensions menu
+            var extensionsMenuItem = dynamoMenuItems.Where(item => item.Header.ToString() == "_View");
 
             if (extensionsMenuItem.Count() > 0)
             {

--- a/TuneUpTests/TuneUpTests.cs
+++ b/TuneUpTests/TuneUpTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using Dynamo.Graph.Workspaces;
@@ -30,7 +31,7 @@ namespace TuneUpTests
             return tuneUpVE as TuneUpViewExtension;
         }
 
-        [Test, RequiresSTA]
+        [Test, Apartment(ApartmentState.STA)]
         public void TuneUpCreatesProfilingDataForEveryNodeInWorkspace()
         {
             // Open test graph
@@ -63,7 +64,7 @@ namespace TuneUpTests
             }
         }
 
-        [Test, RequiresSTA]
+        [Test, Apartment(ApartmentState.STA)]
         public void TuneUpMaintainsProfiledNodeState()
         {
             // Open test graph
@@ -122,7 +123,7 @@ namespace TuneUpTests
             }
         }
 
-        [Test, RequiresSTA]
+        [Test, Apartment(ApartmentState.STA)]
         public void TuneUpDeterminesCorrectNodeExecutionOrder()
         {
             // Expected execution order

--- a/TuneUpTests/TuneUpTests.csproj
+++ b/TuneUpTests/TuneUpTests.csproj
@@ -72,16 +72,22 @@
 
   <!-- Package references -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.Core" Version="3.0.0.7186" />
-    <PackageReference Include="DynamoVisualProgramming.DynamoServices">
-      <Version>3.0.0.7186</Version>
-    </PackageReference>
-    <PackageReference Include="DynamoVisualProgramming.Tests">
-      <Version>3.0.0.7186</Version>
-    </PackageReference>
-    <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary">
-      <Version>3.0.0.7186</Version>
-    </PackageReference>
+    <PackageReference Include="DynamoVisualProgramming.Core" Version="3.2.1.5366">
+      <ExcludeAssets>runtime</ExcludeAssets>
+	  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
+	</PackageReference>
+    <PackageReference Include="DynamoVisualProgramming.Tests" Version="3.2.1.5366">
+	  <ExcludeAssets>runtime</ExcludeAssets>
+	  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
+	</PackageReference>
+    <PackageReference Include="DynamoVisualProgramming.WpfUILibrary" Version="3.2.1.5366">
+	  <ExcludeAssets>runtime</ExcludeAssets>
+	  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
+	</PackageReference>
+    <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary" Version="3.2.1.5366">
+	  <ExcludeAssets>runtime</ExcludeAssets>
+	  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
+	</PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="MSTest.TestAdapter">
       <Version>1.3.2</Version>

--- a/TuneUpTests/TuneUpTests.csproj
+++ b/TuneUpTests/TuneUpTests.csproj
@@ -4,6 +4,7 @@
 
   <!-- Default properties for the project -->
   <PropertyGroup>
+	<!-- Disable default inclusion of all *.cs files to avoid duplicate compile item errors. -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>TuneUpTests</RootNamespace>
@@ -13,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+	<!-- Prevent generation of AssemblyInfo.cs to avoid duplicate attributes. -->
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <!-- Properties specific to Debug configuration -->
@@ -69,9 +72,7 @@
 
   <!-- Package references -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.Core">
-      <Version>3.0.0.7186</Version>
-    </PackageReference>
+    <PackageReference Include="DynamoVisualProgramming.Core" Version="3.0.0.7186" />
     <PackageReference Include="DynamoVisualProgramming.DynamoServices">
       <Version>3.0.0.7186</Version>
     </PackageReference>
@@ -81,15 +82,15 @@
     <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary">
       <Version>3.0.0.7186</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="MSTest.TestAdapter">
       <Version>1.3.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
       <Version>1.3.2</Version>
     </PackageReference>
-    <PackageReference Include="NUnitTestAdapter">
-      <Version>2.2.0</Version>
-    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <!-- Import necessary for test tools -->

--- a/TuneUpTests/TuneUpTests.csproj
+++ b/TuneUpTests/TuneUpTests.csproj
@@ -1,23 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <Project Sdk="Microsoft.NET.Sdk">
-
   <!-- Default properties for the project -->
   <PropertyGroup>
-	<!-- Disable default inclusion of all *.cs files to avoid duplicate compile item errors. -->
-    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>TuneUpTests</RootNamespace>
     <AssemblyName>TuneUpTests</AssemblyName>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <FileAlignment>512</FileAlignment>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-	<!-- Prevent generation of AssemblyInfo.cs to avoid duplicate attributes. -->
-	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-
   <!-- Properties specific to Debug configuration -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -28,7 +21,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-
   <!-- Properties specific to Release configuration -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>pdbonly</DebugType>
@@ -38,7 +30,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-
   <!-- References to other assemblies -->
   <ItemGroup>
     <Reference Include="PresentationCore" />
@@ -55,13 +46,11 @@
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-
   <!-- Source code files to be compiled -->
   <ItemGroup>
     <Compile Include="TuneUpTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-
   <!-- Reference to the main project -->
   <ItemGroup>
     <ProjectReference Include="..\TuneUp\TuneUp.csproj">
@@ -69,36 +58,27 @@
       <Name>TuneUp</Name>
     </ProjectReference>
   </ItemGroup>
-
   <!-- Package references -->
   <ItemGroup>
-    <PackageReference Include="DynamoVisualProgramming.Core" Version="3.2.1.5366">
+    <PackageReference Include="DynamoVisualProgramming.Core" Version="$(DynamoPackageVersion)">
       <ExcludeAssets>runtime</ExcludeAssets>
 	  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
 	</PackageReference>
-    <PackageReference Include="DynamoVisualProgramming.Tests" Version="3.2.1.5366">
+    <PackageReference Include="DynamoVisualProgramming.Tests" Version="$(DynamoPackageVersion)">
 	  <ExcludeAssets>runtime</ExcludeAssets>
 	  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
 	</PackageReference>
-    <PackageReference Include="DynamoVisualProgramming.WpfUILibrary" Version="3.2.1.5366">
+    <PackageReference Include="DynamoVisualProgramming.WpfUILibrary" Version="$(DynamoPackageVersion)">
 	  <ExcludeAssets>runtime</ExcludeAssets>
 	  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
 	</PackageReference>
-    <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary" Version="3.2.1.5366">
+    <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary" Version="$(DynamoPackageVersion)">
 	  <ExcludeAssets>runtime</ExcludeAssets>
 	  <IncludeAssets>compile; build; native; contentfiles; analyzers</IncludeAssets>
 	</PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="MSTest.TestAdapter">
-      <Version>1.3.2</Version>
-    </PackageReference>
-    <PackageReference Include="MSTest.TestFramework">
-      <Version>1.3.2</Version>
-    </PackageReference>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestVersion)" />
   </ItemGroup>
-
   <!-- Import necessary for test tools -->
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
 </Project>

--- a/TuneUpTests/TuneUpTests.csproj
+++ b/TuneUpTests/TuneUpTests.csproj
@@ -1,36 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Default properties for the project -->
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B6817785-AFD9-4AF5-9562-5808E74B53E7}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>TuneUpTests</RootNamespace>
     <AssemblyName>TuneUpTests</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+
+  <!-- Properties specific to Debug configuration -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+
+  <!-- Properties specific to Release configuration -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -38,6 +35,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <!-- References to other assemblies -->
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -53,28 +52,34 @@
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
+
+  <!-- Source code files to be compiled -->
   <ItemGroup>
     <Compile Include="TuneUpTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
+  <!-- Reference to the main project -->
   <ItemGroup>
     <ProjectReference Include="..\TuneUp\TuneUp.csproj">
       <Project>{6ff12d3a-025e-49a5-a773-d99ab82778a3}</Project>
       <Name>TuneUp</Name>
     </ProjectReference>
   </ItemGroup>
+
+  <!-- Package references -->
   <ItemGroup>
     <PackageReference Include="DynamoVisualProgramming.Core">
-      <Version>2.12.0.5650</Version>
+      <Version>3.0.0.7186</Version>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.DynamoServices">
-      <Version>2.12.0.5650</Version>
+      <Version>3.0.0.7186</Version>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.Tests">
-      <Version>2.12.0.5650</Version>
+      <Version>3.0.0.7186</Version>
     </PackageReference>
     <PackageReference Include="DynamoVisualProgramming.ZeroTouchLibrary">
-      <Version>2.12.0.5650</Version>
+      <Version>3.0.0.7186</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>1.3.2</Version>
@@ -86,6 +91,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
   </ItemGroup>
+
+  <!-- Import necessary for test tools -->
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
As per this tread: https://autodesk.slack.com/archives/CPJ5UQW0Z/p1718630160699509

- `DynamoVisualProgramming` packages are updated to the latest version
- `NUnit` is replaced with `NUnit3` (+ NUnit3TestAdapter)
- Disabled default inclusion of all `*.cs` files to avoid duplicate compile item errors
- Disabled generation of `AssemblyInfo.cs` to avoid duplicate attributes
- Disabled default inclusion of all `*.xaml` files to avoid duplicate page item errors
- Depreciated `RequiresSTA` is replaced with `Apartment(ApartmentState.STA)` in unit tests