### PR TITLE
[DYN-3033] TuneUp shouldn't change the graph view when opened

### DIFF
--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -123,7 +123,9 @@
             CanUserResizeColumns="True" 
             CanUserSortColumns="True"
             HeadersVisibility="Column"
-            SelectionChanged="NodeAnalysisTable_SelectionChanged">
+            SelectionChanged="NodeAnalysisTable_SelectionChanged"
+            PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+            MouseLeave="NodeAnalysisTable_MouseLeave" >
 
                 <DataGrid.GroupStyle>
                     <GroupStyle>

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -28,6 +28,12 @@ namespace TuneUp
         private string uniqueId;
 
         /// <summary>
+        /// A flag indicating whether the current selection change in the DataGrid 
+        /// is initiated by the user (true) or programmatically (false).
+        /// </summary>
+        private bool isUserInitiatedSelection = false;
+
+        /// <summary>
         /// Since there is no API for height offset comparing to
         /// DynamoWindow height. Define it as static for now.
         /// </summary>
@@ -58,6 +64,8 @@ namespace TuneUp
 
         private void NodeAnalysisTable_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (!isUserInitiatedSelection) return;
+
             // Get NodeModel(s) that correspond to selected row(s)
             var selectedNodes = new List<NodeModel>();
             foreach (var item in e.AddedItems)
@@ -79,6 +87,24 @@ namespace TuneUp
                 // Focus on selected
                 viewModelCommandExecutive.FindByIdCommand(selectedNodes.First().GUID.ToString());
             }
+        }
+
+        /// <summary>
+        /// Handles the PreviewMouseDown event for the NodeAnalysisTable DataGrid.
+        /// Sets a flag to indicate that the selection change is user-initiated.
+        /// </summary>
+        private void NodeAnalysisTable_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            isUserInitiatedSelection = true;
+        }
+
+        /// <summary>
+        /// Handles the MouseLeave event for the NodeAnalysisTable DataGrid.
+        /// Resets the flag to indicate that the selection change is no longer user-initiated.
+        /// </summary>
+        private void NodeAnalysisTable_MouseLeave(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            isUserInitiatedSelection = false;
         }
 
         internal void Dispose()


### PR DESCRIPTION
PR aims to address https://jira.autodesk.com/browse/DYN-3033

![DYN-3033-Fix](https://github.com/DynamoDS/TuneUp/assets/48355182/537916f9-f9eb-4bb6-b342-6b82013c05aa)

`isUserInitiatedSelection` to flag if the nodes in DataGrid are selected by the user. This prevents `NodeAnalysisTable_SelectionChanged` focusing on selected nodes when TuneUp loads or CurrentWorkspace changes.

FYI
@QilongTang
@reddyashish
@Amoursol