### PR TITLE
[DYN-2475] Icons for sorting on datagrid headers

### DIFF
--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -4,11 +4,19 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:TuneUp"
+             xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
              xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300"
              Width="500" Height="100">
-
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
     <Grid Name="MainGrid" >
         <Grid.Resources>
             <!-- DataGrid style -->
@@ -27,11 +35,59 @@
             <Style x:Key="ColumnHeaderStyle1" TargetType="DataGridColumnHeader">
                 <Setter Property="Height" Value="20"/>
                 <Setter Property="Background" Value="#333333"/>
-                <Setter Property="Foreground" Value="#999999"/>
-                <Setter Property="FontSize" Value="10" />
-                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
+                <Setter Property="FontSize" Value="10"/>
+                <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="BorderBrush" Value="#555555"/>
-                <Setter Property="Margin" Value="10,0,10,0"/>
+                <Setter Property="Margin" Value="5,0,10,0"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter x:Name="HeaderContent"
+                                                  Grid.Column="1"
+                                                  VerticalAlignment="Center"
+                                                  HorizontalAlignment="Left"
+                                                  Margin="11,0,0,0"/>
+                                <Path x:Name="SortArrow"
+                                      Data="M0,0 L0,2 L4,6 L8,2 L8,0 L4,4 z"
+                                      Grid.Column="0"
+                                      Margin="0,0,4,0"
+                                      Stretch="Fill"
+                                      Width="7" Height="6"
+                                      Fill="#999999"                                      
+                                      VerticalAlignment="Center"
+                                      RenderTransformOrigin="0.5,0.5"
+                                      Visibility="Collapsed"/>
+                            </Grid>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="SortDirection" Value="Ascending">
+                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0"/>
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="SortArrow" Property="RenderTransform">
+                                        <Setter.Value>
+                                            <RotateTransform Angle="180"/>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Trigger>
+                                <Trigger Property="SortDirection" Value="Descending">
+                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0"/>
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="SortArrow" Property="RenderTransform">
+                                        <Setter.Value>
+                                            <RotateTransform Angle="0"/>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
             </Style>
             <!-- DataGridRow style -->
             <Style x:Key="RowStyle1" TargetType="DataGridRow">
@@ -70,6 +126,13 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+            <!-- TextBlock style for DataGrid columns -->
+            <Style x:Key="DataGridTextBlockStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
+                <Setter Property="VerticalAlignment" Value="Center"/>
+                <Setter Property="Margin" Value="10,0,10,0"/>
+            </Style>
             <Style x:Key="ButtonStyle1" TargetType="{x:Type Button}">
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
@@ -82,7 +145,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-
         <!-- Recompute All Button -->
         <StackPanel 
             Orientation="Horizontal"
@@ -98,12 +160,12 @@
                 Padding="5,2,5,2">
                 Force Re-execute
             </Button>
-            <Label Foreground="White">Total Graph Execution Time: </Label>
-            <Label Foreground="White"
+            <Label Foreground="{StaticResource NodeNameForeground}">Total Graph Execution Time:</Label>
+            <Label Foreground="{StaticResource NodeNameForeground}"
+                   FontFamily="{StaticResource ArtifaktElementRegular}"
                    Name="TotalGraphExecutiontimeLabel"
                    Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"/>
         </StackPanel>
-
         <StackPanel Grid.Row="1">
             <DataGrid 
             x:Name="NodeAnalysisTable" 
@@ -112,7 +174,7 @@
             Style="{StaticResource DataGridStyle1}"
             AutoGenerateColumns="False"
             CanUserAddRows="False"
-            Background="#353535"
+            Background="#353535"    
             FontSize="11"
             VerticalAlignment="Center"
             SelectionUnit="FullRow"
@@ -123,8 +185,8 @@
             CanUserResizeColumns="True" 
             CanUserSortColumns="True"
             HeadersVisibility="Column"
-            SelectionChanged="NodeAnalysisTable_SelectionChanged">
-
+            SelectionChanged="NodeAnalysisTable_SelectionChanged"
+            Sorting="NodeAnalysisTable_Sorting" >
                 <DataGrid.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.HeaderTemplate>
@@ -132,7 +194,8 @@
                                 <StackPanel>
                                     <TextBlock 
                                         Text="{Binding Name}"
-                                        Foreground="#ffffff"
+                                        Foreground="{StaticResource NodeNameForeground}"
+                                        FontFamily="{StaticResource ArtifaktElementRegular}" 
                                         Margin="3"
                                         FontSize="12"
                                         />
@@ -141,15 +204,14 @@
                         </GroupStyle.HeaderTemplate>
                     </GroupStyle>
                 </DataGrid.GroupStyle>
-
                 <DataGrid.Columns>
-
                     <!-- Execution Order -->
                     <DataGridTextColumn 
                     Header="#" 
                     Binding="{Binding Path=ExecutionOrderNumber}" 
-                    Foreground="#aaaaaa" 
-                    IsReadOnly="True" 
+                    Foreground="{StaticResource MemberButtonText}"
+                    FontFamily="{StaticResource ArtifaktElementRegular}" 
+                    IsReadOnly="True"
                     Width="Auto">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
@@ -158,12 +220,12 @@
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-
                     <!-- Node Name -->
                     <DataGridTextColumn 
                     Header="Name" 
                     Binding="{Binding Name}" 
-                    Foreground="#aaaaaa" 
+                    Foreground="{StaticResource MemberButtonText}"
+                    FontFamily="{StaticResource ArtifaktElementRegular}"
                     IsReadOnly="True" 
                     Width="*">
                         <DataGridTextColumn.ElementStyle>
@@ -173,12 +235,12 @@
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-
                     <!-- Execution Time -->
                     <DataGridTextColumn 
                     Header="Execution Time (ms)" 
                     Binding="{Binding ExecutionMilliseconds}" 
-                    Foreground="#aaaaaa" 
+                    Foreground="{StaticResource MemberButtonText}"
+                    FontFamily="{StaticResource ArtifaktElementRegular}"
                     IsReadOnly="True" 
                     Width="Auto">
                         <DataGridTextColumn.ElementStyle>
@@ -188,7 +250,6 @@
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-
                 </DataGrid.Columns>
             </DataGrid>
         </StackPanel>

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -90,5 +91,34 @@ namespace TuneUp
         {
             (NodeAnalysisTable.DataContext as TuneUpWindowViewModel).ResetProfiling();
         }
+
+        /// <summary>
+        /// Handles the sorting event for the NodeAnalysisTable DataGrid.
+        /// Updates the SortingOrder property in the view model based on the column header clicked by the user.
+        /// </summary>
+        private void NodeAnalysisTable_Sorting(object sender, DataGridSortingEventArgs e)
+        {
+            var viewModel = NodeAnalysisTable.DataContext as TuneUpWindowViewModel;
+            if (viewModel != null)
+            {
+                viewModel.SortingOrder = e.Column.Header switch
+                {
+                    "#" => "number",
+                    "Name" => "name",
+                    "Execution Time (ms)" => "time",
+                    _ => viewModel.SortingOrder
+                };
+
+                // Set the sorting direction of the datagrid column
+                e.Column.SortDirection = viewModel.SortDirection == ListSortDirection.Descending
+                    ? ListSortDirection.Descending
+                    : ListSortDirection.Ascending;
+
+                // Apply custom sorting to ensure total times are at the bottom
+                viewModel.ApplySorting();
+                e.Handled = true;
+            }
+        }
+
     }
 }


### PR DESCRIPTION
PR aiming to address https://jira.autodesk.com/browse/DYN-2475 🤞
- arrows appear when user changes the default sorting order / direction
- sorting order and direction are now kept on the next graph execution and revert back to default when TuneUp is closed

![DYN-2475](https://github.com/DynamoDS/TuneUp/assets/48355182/7ae4e11c-fa1e-40c9-aaa4-3c17b6bacdb1)

FYI
@QilongTang
@reddyashish
@Amoursol