### PR TITLE
[DYN-2369] Export TuneUp node timings

### DIFF
--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -96,7 +96,17 @@
                 IsEnabled="{Binding  Path=IsRecomputeEnabled}"
                 Click="RecomputeGraph_Click"
                 Padding="5,2,5,2">
-                Force Re-execute
+                Run All
+            </Button>
+            <Button
+                Name="ExportTimes"
+                Width="Auto"
+                Height="Auto"
+                Margin="2,1,1,10"
+                Padding="5,2,5,2"
+                IsEnabled="{Binding  Path=IsRecomputeEnabled}"
+                Click="ExportTimes_Click">
+                Export
             </Button>
             <Label Foreground="White">Total Graph Execution Time: </Label>
             <Label Foreground="White"

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -90,5 +90,10 @@ namespace TuneUp
         {
             (NodeAnalysisTable.DataContext as TuneUpWindowViewModel).ResetProfiling();
         }
+
+        private void ExportTimes_Click(object sender, RoutedEventArgs e)
+        {
+            (NodeAnalysisTable.DataContext as TuneUpWindowViewModel).ExportToCsv();
+        }
     }
 }

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Windows.Data;
@@ -12,6 +13,7 @@ using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
 using Dynamo.ViewModels;
 using Dynamo.Wpf.Extensions;
+using Microsoft.Win32;
 
 namespace TuneUp
 {
@@ -445,6 +447,33 @@ namespace TuneUp
             ManageWorkspaceEvents(CurrentWorkspace, false);
             viewLoadedParams.CurrentWorkspaceChanged -= OnCurrentWorkspaceChanged;
             viewLoadedParams.CurrentWorkspaceCleared -= OnCurrentWorkspaceCleared;
+        }
+
+        #endregion
+
+        #region Export Node times
+
+        /// <summary>
+        /// Exports the ProfiledNodesCollection to a CSV file.
+        /// </summary>
+        public void ExportToCsv()
+        {
+            SaveFileDialog saveFileDialog = new SaveFileDialog();
+            //saveFileDialog.RestoreDirectory = false;
+            saveFileDialog.Filter = "CSV file (*.csv)|*.csv|All files (*.*)|*.*";
+
+            if (saveFileDialog.ShowDialog() == true)
+            {
+                using (var writer = new StreamWriter(saveFileDialog.FileName))
+                {
+                    writer.WriteLine("Execution Order,Name,Execution Time (ms)");
+
+                    foreach (ProfiledNodeViewModel node in ProfiledNodesCollection.View.Cast<ProfiledNodeViewModel>())
+                    {
+                        writer.WriteLine($"{node.ExecutionOrderNumber},{node.Name},{node.ExecutionMilliseconds}");
+                    }
+                }
+            }
         }
 
         #endregion


### PR DESCRIPTION
PR aims to address https://jira.autodesk.com/browse/DYN-2369 🤞
- exports csv files with the data from `NodeAnalysisTable` (assuming this is the most appropriate format for the majority of Dynamo users) 
- new button in the UI for export
- Force Re-run button renamed to Run All as per TuneUp's ReadMe.md

![DYN-2369](https://github.com/DynamoDS/TuneUp/assets/48355182/4ee2b398-f399-4dbf-8ee3-f8928d6c2bec)

FYI
@QilongTang
@reddyashish
@Amoursol