### PR TITLE
DRAFT[DYN-2332] As a user I want Tuneup times color coded to visually highlight hot spots

### DIFF
--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -2,12 +2,67 @@
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
+using System.Windows.Media;
 using Dynamo.Core;
 using Dynamo.Graph.Nodes;
 namespace TuneUp
 {
     public class ProfiledNodeViewModel : NotificationObject
     {
+        internal SolidColorBrush hotspotMinValueBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#B7D78C"));
+        internal SolidColorBrush hotspotMaxValueBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#EB5555"));
+        internal SolidColorBrush defaultRowBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AAAAAA"));
+
+        private int hotspotMinValue;
+        private int hotspotMaxValue;
+        public int HotspotMinValue
+        {
+            get => hotspotMinValue;
+            set
+            {
+                if (hotspotMinValue != value)
+                {
+                    hotspotMinValue = value;
+                    RaisePropertyChanged(nameof(HotspotMinValue));
+                    RaisePropertyChanged(nameof(RowBackground));
+                }
+            }
+        }
+        public int HotspotMaxValue
+        {
+            get => hotspotMaxValue;
+            set
+            {
+                if (hotspotMaxValue != value)
+                {
+                    hotspotMaxValue = value;
+                    RaisePropertyChanged(nameof(HotspotMaxValue));
+                    RaisePropertyChanged(nameof(RowBackground));
+                }
+            }
+        }
+        public Brush RowBackground
+        {
+            get
+            {
+                if (ExecutionMilliseconds < HotspotMinValue && HotspotMinValue > 0 && State != ProfiledNodeState.NotExecuted)
+                {
+                    return hotspotMinValueBrush;
+                }
+                if (ExecutionMilliseconds > HotspotMaxValue && HotspotMaxValue > 0 && State != ProfiledNodeState.NotExecuted)
+                {
+                    return hotspotMaxValueBrush;
+                }
+                return defaultRowBrush;
+            }
+        }
+        public void UpdateHotspotValues(int minVal, int maxVal)
+        {
+            HotspotMinValue = minVal;
+            HotspotMaxValue = maxVal;
+        }
+
+
         #region Properties
         /// <summary>
         /// Prefix string of execution time.
@@ -22,7 +77,7 @@ namespace TuneUp
         /// </summary>
         public string Name
         {
-            get 
+            get
             {
                 // For virtual row, do not attempt to grab node name
                 if (!name.Contains(ExecutionTimelString))
@@ -31,7 +86,7 @@ namespace TuneUp
             }
             internal set { name = value; }
         }
-        
+
         /// <summary>
         /// The order number of this node in the most recent graph run.
         /// Returns null if the node was not executed during the most recent graph run.
@@ -65,6 +120,8 @@ namespace TuneUp
                 executionTime = value;
                 RaisePropertyChanged(nameof(ExecutionTime));
                 RaisePropertyChanged(nameof(ExecutionMilliseconds));
+                // IP ADDED
+                RaisePropertyChanged(nameof(RowBackground));
             }
         }
         private TimeSpan executionTime;
@@ -74,10 +131,13 @@ namespace TuneUp
         /// </summary>
         public int ExecutionMilliseconds
         {
-            get
-            {
-                return (int)Math.Round(ExecutionTime.TotalMilliseconds);
-            }
+            get => (int)Math.Round(ExecutionTime.TotalMilliseconds);
+            //set
+            //{
+            //    executionMilliseconds = value;
+            //    RaisePropertyChanged(nameof(ExecutionMilliseconds));
+            //    RaisePropertyChanged(nameof(RowBackground));
+            //}
         }
 
         /// <summary>

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -1,73 +1,24 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Media;
 using Dynamo.Core;
+using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Nodes;
+
 namespace TuneUp
 {
     public class ProfiledNodeViewModel : NotificationObject
     {
-        internal SolidColorBrush hotspotMinValueBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#B7D78C"));
-        internal SolidColorBrush hotspotMaxValueBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#EB5555"));
-        internal SolidColorBrush defaultRowBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AAAAAA"));
-
-        private int hotspotMinValue;
-        private int hotspotMaxValue;
-        public int HotspotMinValue
-        {
-            get => hotspotMinValue;
-            set
-            {
-                if (hotspotMinValue != value)
-                {
-                    hotspotMinValue = value;
-                    RaisePropertyChanged(nameof(HotspotMinValue));
-                    RaisePropertyChanged(nameof(RowBackground));
-                }
-            }
-        }
-        public int HotspotMaxValue
-        {
-            get => hotspotMaxValue;
-            set
-            {
-                if (hotspotMaxValue != value)
-                {
-                    hotspotMaxValue = value;
-                    RaisePropertyChanged(nameof(HotspotMaxValue));
-                    RaisePropertyChanged(nameof(RowBackground));
-                }
-            }
-        }
-        public Brush RowBackground
-        {
-            get
-            {
-                if (ExecutionMilliseconds < HotspotMinValue && HotspotMinValue > 0 && State != ProfiledNodeState.NotExecuted)
-                {
-                    return hotspotMinValueBrush;
-                }
-                if (ExecutionMilliseconds > HotspotMaxValue && HotspotMaxValue > 0 && State != ProfiledNodeState.NotExecuted)
-                {
-                    return hotspotMaxValueBrush;
-                }
-                return defaultRowBrush;
-            }
-        }
-        public void UpdateHotspotValues(int minVal, int maxVal)
-        {
-            HotspotMinValue = minVal;
-            HotspotMaxValue = maxVal;
-        }
-
-
         #region Properties
         /// <summary>
         /// Prefix string of execution time.
         /// </summary>
         public static readonly string ExecutionTimelString = "Execution Time";
+
+        public static readonly string GroupNodePrefix = "Group: ";
 
         private string name = String.Empty;
         /// <summary>
@@ -80,7 +31,7 @@ namespace TuneUp
             get
             {
                 // For virtual row, do not attempt to grab node name
-                if (!name.Contains(ExecutionTimelString))
+                if (!name.Contains(ExecutionTimelString) && !name.StartsWith(GroupNodePrefix))
                     name = NodeModel?.Name;
                 return name;
             }
@@ -93,10 +44,7 @@ namespace TuneUp
         /// </summary>
         public int? ExecutionOrderNumber
         {
-            get
-            {
-                return executionOrderNumber;
-            }
+            get => executionOrderNumber;
             set
             {
                 executionOrderNumber = value;
@@ -105,26 +53,49 @@ namespace TuneUp
         }
         private int? executionOrderNumber;
 
+        /// <summary>
+        /// The order number of this group in the most recent graph run.
+        /// This number is assigned to each node within the group.
+        /// </summary>
+        public int? GroupExecutionOrderNumber
+        {
+            get => groupExecutionOrderNumber;
+            set
+            {
+                groupExecutionOrderNumber = value;
+                RaisePropertyChanged(nameof(GroupExecutionOrderNumber));
+            }
+        }
+        private int? groupExecutionOrderNumber;
 
         /// <summary>
         /// The most recent execution time of this node
         /// </summary>
         public TimeSpan ExecutionTime
         {
-            get
-            {
-                return executionTime;
-            }
+            get => executionTime;
             set
             {
                 executionTime = value;
                 RaisePropertyChanged(nameof(ExecutionTime));
                 RaisePropertyChanged(nameof(ExecutionMilliseconds));
-                // IP ADDED
-                RaisePropertyChanged(nameof(RowBackground));
             }
         }
         private TimeSpan executionTime;
+
+        /// <summary>
+        /// The total execution time of all node in the group.
+        /// </summary>
+        public TimeSpan GroupExecutionTime
+        {
+            get => groupExecutionTime;
+            set
+            {
+                groupExecutionTime = value;
+                RaisePropertyChanged(nameof(GroupExecutionTime));
+            }
+        }
+        private TimeSpan groupExecutionTime;
 
         /// <summary>
         /// The most recent execution time of this node in milliseconds
@@ -132,12 +103,6 @@ namespace TuneUp
         public int ExecutionMilliseconds
         {
             get => (int)Math.Round(ExecutionTime.TotalMilliseconds);
-            //set
-            //{
-            //    executionMilliseconds = value;
-            //    RaisePropertyChanged(nameof(ExecutionMilliseconds));
-            //    RaisePropertyChanged(nameof(RowBackground));
-            //}
         }
 
         /// <summary>
@@ -145,10 +110,7 @@ namespace TuneUp
         /// </summary>
         public bool WasExecutedOnLastRun
         {
-            get
-            {
-                return wasExecutedOnLastRun;
-            }
+            get => wasExecutedOnLastRun;
             set
             {
                 wasExecutedOnLastRun = value;
@@ -162,10 +124,7 @@ namespace TuneUp
         /// </summary>
         public ProfiledNodeState State
         {
-            get
-            {
-                return state;
-            }
+            get => state;
             set
             {
                 state = value;
@@ -173,6 +132,81 @@ namespace TuneUp
             }
         }
         private ProfiledNodeState state;
+
+        /// <summary>
+        /// The current hotspot state based on execution time and configured hotspot values
+        /// </summary>
+        public ProfiledNodeHotspotState HotspotState
+        {
+            get => hotspotState;
+            set
+            {
+                hotspotState = value;
+                RaisePropertyChanged(nameof(HotspotState));
+            }
+        }
+        private ProfiledNodeHotspotState hotspotState;
+
+        /// <summary>
+        /// The GUID of the group to which this node belongs
+        /// </summary>
+        public Guid GroupGUID
+        {
+            get => groupGIUD;
+            set
+            {
+                groupGIUD = value;
+                RaisePropertyChanged(nameof(GroupGUID));
+            }
+        }
+        private Guid groupGIUD;
+
+        /// <summary>
+        /// The name of the group to which this node belongs
+        /// This property is also applied to individual nodes and is used when sorting by name
+        /// </summary>
+        public string GroupName
+        {
+            get => groupName;
+            set
+            {
+                groupName = value;
+                RaisePropertyChanged(nameof(GroupName));
+            }
+        }
+        private string groupName;
+
+        /// <summary>
+        /// Indicates if this node is a group
+        /// </summary>
+        public bool IsGroup
+        {
+            get => isGroup;
+            set
+            {
+                isGroup = value;
+                RaisePropertyChanged(nameof(IsGroup));
+            }
+        }
+        private bool isGroup;
+
+        /// <summary>
+        /// The background brush for this node
+        /// If this node represents a group, it inherits the background color from the associated AnnotationModel
+        /// </summary>
+        public SolidColorBrush BackgroundBrush
+        {
+            get => backgroundBrush;
+            set
+            {
+                if (value != null)
+                {
+                    backgroundBrush = value;
+                    RaisePropertyChanged(nameof(BackgroundBrush));
+                }
+            }
+        }
+        private SolidColorBrush backgroundBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
 
         /// <summary>
         /// Return the display name of state enum.
@@ -190,6 +224,11 @@ namespace TuneUp
             }
         }
 
+        /// <summary>
+        /// The Stopwatch to measure execution time of this node
+        /// </summary>
+        internal Stopwatch Stopwatch { get; set; }
+
         internal NodeModel NodeModel { get; set; }
 
         #endregion
@@ -202,6 +241,7 @@ namespace TuneUp
         {
             NodeModel = node;
             State = ProfiledNodeState.NotExecuted;
+            Stopwatch = new Stopwatch();
         }
 
         /// <summary>
@@ -216,6 +256,21 @@ namespace TuneUp
             this.Name = name;
             this.ExecutionTime = exTimeSum;
             State = state;
+        }
+
+        /// <summary>
+        /// An alternative constructor to represent an annotation model as a group node.
+        /// </summary>
+        /// <param name="group">the annotation model</param>
+        public ProfiledNodeViewModel(AnnotationModel group)
+        {
+            NodeModel = null;
+            Name = $"{GroupNodePrefix}{group.AnnotationText}";
+            GroupName = group.AnnotationText;
+            GroupGUID = group.GUID;
+            BackgroundBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString(group.Background));
+            IsGroup = true;
+            State = ProfiledNodeState.NotExecuted;
         }
     }
 }

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -1,43 +1,58 @@
-﻿<Window x:Class="TuneUp.TuneUpWindow"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:TuneUp"
-             xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
-             mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300"
-             Width="500" Height="100">
+﻿<Window
+    x:Class="TuneUp.TuneUpWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:TuneUp"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+    Width="500"
+    Height="100"
+    d:DesignHeight="300"
+    d:DesignWidth="300"
+    mc:Ignorable="d">
 
-    <Grid Name="MainGrid" >
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
+                <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
+            </ResourceDictionary.MergedDictionaries>
+            <local:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Name="MainGrid">
         <Grid.Resources>
-            <!-- DataGrid style -->
+            <!--  DataGrid style  -->
             <Style x:Key="DataGridStyle1" TargetType="{x:Type DataGrid}">
-                <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle1}"/>
-                <Setter Property="RowStyle" Value="{DynamicResource RowStyle1}"/>
-                <Setter Property="CellStyle" Value="{DynamicResource CellStyle1}"/>
-                <Setter Property="RowHeaderWidth" Value="0"/>
+                <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle1}" />
+                <Setter Property="RowStyle" Value="{DynamicResource RowStyle1}" />
+                <Setter Property="CellStyle" Value="{DynamicResource CellStyle1}" />
+                <Setter Property="RowHeaderWidth" Value="0" />
                 <Setter Property="BorderThickness" Value="0.5" />
-                <Setter Property="BorderBrush" Value="#555555"/>
-                <Setter Property="ColumnWidth" Value="Auto"/>
-                <Setter Property="GridLinesVisibility" Value="Vertical"/>
-                <Setter Property="VerticalGridLinesBrush" Value="#555555"/>
+                <Setter Property="BorderBrush" Value="#555555" />
+                <Setter Property="ColumnWidth" Value="Auto" />
+                <Setter Property="GridLinesVisibility" Value="Vertical" />
+                <Setter Property="VerticalGridLinesBrush" Value="#555555" />
             </Style>
-            <!-- DataGridColumnHeader style -->
+            <!--  DataGridColumnHeader style  -->
             <Style x:Key="ColumnHeaderStyle1" TargetType="DataGridColumnHeader">
-                <Setter Property="Height" Value="20"/>
-                <Setter Property="Background" Value="#333333"/>
-                <Setter Property="Foreground" Value="#999999"/>
+                <Setter Property="Height" Value="20" />
+                <Setter Property="Background" Value="#333333" />
+                <Setter Property="Foreground" Value="#999999" />
                 <Setter Property="FontSize" Value="10" />
                 <Setter Property="BorderThickness" Value="0" />
-                <Setter Property="BorderBrush" Value="#555555"/>
-                <Setter Property="Margin" Value="10,0,10,0"/>
+                <Setter Property="BorderBrush" Value="#555555" />
+                <Setter Property="Margin" Value="10,0,10,0" />
             </Style>
-            <!-- DataGridRow style -->
+            <!--  DataGridRow style  -->
             <Style x:Key="RowStyle1" TargetType="DataGridRow">
                 <Setter Property="Background" Value="#333333"/>
+                <Setter Property="Foreground" Value="{Binding RowBackground}" />
                 <Setter Property="BorderThickness" Value="0.45" />
-                <Setter Property="BorderBrush" Value="#555555"/>
+                <Setter Property="BorderBrush" Value="#555555" />
                 <Style.Triggers>
                     <Trigger Property="IsSelected" Value="True">
                         <Setter Property="Background" Value="#555555" />
@@ -47,7 +62,7 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <!-- Cell style -->
+            <!--  Cell style  -->
             <Style x:Key="CellStyle1" TargetType="DataGridCell">
                 <Setter Property="BorderThickness" Value="0" />
                 <Setter Property="Margin" Value="1" />
@@ -57,14 +72,14 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <!-- Group Style -->
+            <!--  Group Style  -->
             <Style x:Key="GroupHeaderStyle" TargetType="{x:Type GroupItem}">
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type GroupItem}">
                             <StackPanel>
-                                <TextBlock Text="{Binding Name}"/>
-                                <ItemsPresenter/>
+                                <TextBlock Text="{Binding Name}" />
+                                <ItemsPresenter />
                             </StackPanel>
                         </ControlTemplate>
                     </Setter.Value>
@@ -73,122 +88,165 @@
             <Style x:Key="ButtonStyle1" TargetType="{x:Type Button}">
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="#999999"/>
+                        <Setter Property="Background" Value="#999999" />
                     </Trigger>
                 </Style.Triggers>
+            </Style>
+            <!-- TextBox Style -->
+            <Style x:Key="NumberBoxStyle" TargetType="TextBox">
+                <Setter Property="Height" Value="20" />
+                <Setter Property="MinWidth" Value="25" />
+                <Setter Property="Margin" Value="2,0,0,0" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
+                <Setter Property="Background" Value="{StaticResource PreferencesWindowBackgroundColor}" />
+                <Setter Property="BorderThickness" Value="0,0,0,2" />
+                <Setter Property="FontWeight" Value="Regular" />
+                <Setter Property="Foreground" Value="{StaticResource PreferencesWindowFontColor}" />
+                <Setter Property="Visibility" Value="{Binding Path=ShowHotspotsEnabled, Converter={StaticResource BoolToVisibilityConverter}}" />
+                <EventSetter Event="PreviewTextInput" Handler="NumberValidationTextBox" />
+            </Style>
+            <!-- Label Style -->
+            <Style x:Key="SettingsLabelStyle" TargetType="Label">
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
+                <Setter Property="Foreground" Value="{StaticResource NodeNameForeground}"/>
             </Style>
         </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-
-        <!-- Recompute All Button -->
-        <StackPanel 
-            Orientation="Horizontal"
+        <!--  Recompute All Button  -->
+        <StackPanel
+            Grid.Row="0"
             HorizontalAlignment="Left"
-            Grid.Row="0">
+            Orientation="Horizontal">
             <Button
                 Name="RecomputeGraph"
                 Width="Auto"
                 Height="Auto"
                 Margin="2,1,1,10"
-                IsEnabled="{Binding  Path=IsRecomputeEnabled}"
+                Padding="5,2,5,2"
                 Click="RecomputeGraph_Click"
-                Padding="5,2,5,2">
+                IsEnabled="{Binding Path=IsRecomputeEnabled}">
                 Force Re-execute
             </Button>
-            <Label Foreground="White">Total Graph Execution Time: </Label>
-            <Label Foreground="White"
-                   Name="TotalGraphExecutiontimeLabel"
-                   Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"/>
+            <Label Foreground="White">Total Graph Execution Time:</Label>
+            <Label
+                Name="TotalGraphExecutiontimeLabel"
+                Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"
+                Foreground="White" />
         </StackPanel>
-
-        <StackPanel Grid.Row="1">
-            <DataGrid 
-            x:Name="NodeAnalysisTable" 
+        <!--  Show Hotspots Menu  -->
+        <StackPanel
             Grid.Row="1"
-            ItemsSource="{Binding Path=ProfiledNodesCollection.View}"
-            Style="{StaticResource DataGridStyle1}"
-            AutoGenerateColumns="False"
-            CanUserAddRows="False"
-            Background="#353535"
-            FontSize="11"
-            VerticalAlignment="Center"
-            SelectionUnit="FullRow"
-            SelectionMode="Single"
-            ScrollViewer.CanContentScroll="False" 
-            ScrollViewer.HorizontalScrollBarVisibility="Auto"
-            ScrollViewer.VerticalScrollBarVisibility="Auto"
-            CanUserResizeColumns="True" 
-            CanUserSortColumns="True"
-            HeadersVisibility="Column"
-            SelectionChanged="NodeAnalysisTable_SelectionChanged">
-
+            HorizontalAlignment="Left"
+            Orientation="Horizontal">
+            <ToggleButton
+                Grid.Column="0"
+                Width="40"
+                Height="20"
+                Margin="2,0,0,0"
+                VerticalAlignment="Center"
+                IsEnabled="True"
+                Style="{StaticResource EllipseToggleButton1}"
+                Checked="HotspotToggleButton_Checked"
+                Unchecked="HotspotToggleButton_Checked"/>
+            <Label
+                Content="Show Node Hotspots"
+                Style="{StaticResource SettingsLabelStyle}"/>
+            <TextBox
+                x:Name="MinValueNumberBox"
+                Style="{StaticResource NumberBoxStyle}"
+                Text="{Binding Path=HotspotMinValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            <Label
+                Style="{StaticResource SettingsLabelStyle}"
+                Content="Min value"
+                Visibility="{Binding Path=ShowHotspotsEnabled, Converter={StaticResource BoolToVisibilityConverter}}"/>
+            <TextBox
+                x:Name="MaxValueNumberBox"
+                Style="{StaticResource NumberBoxStyle}"
+                Text="{Binding Path=HotspotMaxValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <Label
+                Style="{StaticResource SettingsLabelStyle}"
+                Content="Max value"
+                Visibility="{Binding Path=ShowHotspotsEnabled, Converter={StaticResource BoolToVisibilityConverter}}"/>
+        </StackPanel>
+        <StackPanel Grid.Row="2">
+            <DataGrid
+                x:Name="NodeAnalysisTable"
+                Grid.Row="2"
+                VerticalAlignment="Center"
+                AutoGenerateColumns="False"
+                Background="#353535"
+                CanUserAddRows="False"
+                CanUserResizeColumns="True"
+                CanUserSortColumns="True"
+                FontSize="11"
+                HeadersVisibility="Column"
+                ItemsSource="{Binding Path=ProfiledNodesCollection.View}"
+                ScrollViewer.CanContentScroll="False"
+                ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                ScrollViewer.VerticalScrollBarVisibility="Auto"
+                SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                SelectionMode="Single"
+                SelectionUnit="FullRow"
+                Style="{StaticResource DataGridStyle1}">
                 <DataGrid.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.HeaderTemplate>
                             <DataTemplate>
                                 <StackPanel>
-                                    <TextBlock 
-                                        Text="{Binding Name}"
-                                        Foreground="#ffffff"
+                                    <TextBlock
                                         Margin="3"
                                         FontSize="12"
-                                        />
+                                        Foreground="#ffffff"
+                                        Text="{Binding Name}" />
                                 </StackPanel>
                             </DataTemplate>
                         </GroupStyle.HeaderTemplate>
                     </GroupStyle>
                 </DataGrid.GroupStyle>
-
                 <DataGrid.Columns>
-
-                    <!-- Execution Order -->
-                    <DataGridTextColumn 
-                    Header="#" 
-                    Binding="{Binding Path=ExecutionOrderNumber}" 
-                    Foreground="#aaaaaa" 
-                    IsReadOnly="True" 
-                    Width="Auto">
+                    <!--  Execution Order  -->
+                    <DataGridTextColumn
+                        Width="Auto"
+                        Binding="{Binding Path=ExecutionOrderNumber}"
+                        Header="#"
+                        IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0"/>
+                                <Setter Property="Margin" Value="10,0,10,0" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-
-                    <!-- Node Name -->
-                    <DataGridTextColumn 
-                    Header="Name" 
-                    Binding="{Binding Name}" 
-                    Foreground="#aaaaaa" 
-                    IsReadOnly="True" 
-                    Width="*">
+                    <!--  Node Name  -->
+                    <DataGridTextColumn
+                        Width="*"
+                        Binding="{Binding Name}"
+                        Header="Name"
+                        IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0"/>
+                                <Setter Property="Margin" Value="10,0,10,0" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-
-                    <!-- Execution Time -->
-                    <DataGridTextColumn 
-                    Header="Execution Time (ms)" 
-                    Binding="{Binding ExecutionMilliseconds}" 
-                    Foreground="#aaaaaa" 
-                    IsReadOnly="True" 
-                    Width="Auto">
+                    <!--  Execution Time  -->
+                    <DataGridTextColumn
+                        Width="Auto"
+                        Binding="{Binding ExecutionMilliseconds}"
+                        Header="Execution Time (ms)"
+                        IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0"/>
+                                <Setter Property="Margin" Value="10,0,10,0" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-
                 </DataGrid.Columns>
             </DataGrid>
         </StackPanel>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -1,70 +1,115 @@
-﻿<Window
-    x:Class="TuneUp.TuneUpWindow"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="clr-namespace:TuneUp"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
-    Width="500"
-    Height="100"
-    d:DesignHeight="300"
-    d:DesignWidth="300"
-    mc:Ignorable="d">
-
+﻿<Window x:Class="TuneUp.TuneUpWindow"
+         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+         xmlns:local="clr-namespace:TuneUp"
+         xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+         xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+         mc:Ignorable="d" 
+         d:DesignHeight="300" d:DesignWidth="300"
+         Width="500" Height="100">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
+            <local:IsGroupToMarginMultiConverter  x:Key="IsGroupToMarginMultiConverter" />
+            <local:IsGroupToVisibilityMultiConverter  x:Key="IsGroupToVisibilityMultiConverter" />
             <local:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+            <local:IsGroupToBrushMultiConverter  x:Key="IsGroupToBrushMultiConverter" />
         </ResourceDictionary>
     </Window.Resources>
-
-    <Grid Name="MainGrid">
+    <Grid Name="MainGrid" >
         <Grid.Resources>
-            <!--  DataGrid style  -->
+            <!-- DataGrid style -->
             <Style x:Key="DataGridStyle1" TargetType="{x:Type DataGrid}">
-                <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle1}" />
-                <Setter Property="RowStyle" Value="{DynamicResource RowStyle1}" />
-                <Setter Property="CellStyle" Value="{DynamicResource CellStyle1}" />
-                <Setter Property="RowHeaderWidth" Value="0" />
+                <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle1}"/>
+                <Setter Property="RowStyle" Value="{DynamicResource RowStyle1}"/>
+                <Setter Property="CellStyle" Value="{DynamicResource CellStyle1}"/>
+                <Setter Property="RowHeaderWidth" Value="0"/>
                 <Setter Property="BorderThickness" Value="0.5" />
-                <Setter Property="BorderBrush" Value="#555555" />
-                <Setter Property="ColumnWidth" Value="Auto" />
-                <Setter Property="GridLinesVisibility" Value="Vertical" />
-                <Setter Property="VerticalGridLinesBrush" Value="#555555" />
+                <Setter Property="BorderBrush" Value="#555555"/>
+                <Setter Property="ColumnWidth" Value="Auto"/>
+                <Setter Property="GridLinesVisibility" Value="Vertical"/>
+                <Setter Property="VerticalGridLinesBrush" Value="#555555"/>
             </Style>
-            <!--  DataGridColumnHeader style  -->
+            <!-- DataGridColumnHeader style -->
             <Style x:Key="ColumnHeaderStyle1" TargetType="DataGridColumnHeader">
-                <Setter Property="Height" Value="20" />
-                <Setter Property="Background" Value="#333333" />
-                <Setter Property="Foreground" Value="#999999" />
-                <Setter Property="FontSize" Value="10" />
-                <Setter Property="BorderThickness" Value="0" />
-                <Setter Property="BorderBrush" Value="#555555" />
-                <Setter Property="Margin" Value="10,0,10,0" />
-            </Style>
-            <!--  DataGridRow style  -->
-            <Style x:Key="RowStyle1" TargetType="DataGridRow">
+                <Setter Property="Height" Value="20"/>
                 <Setter Property="Background" Value="#333333"/>
-                <Setter Property="Foreground" Value="{Binding RowBackground}" />
+                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
+                <Setter Property="FontSize" Value="10"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="BorderBrush" Value="#555555"/>
+                <Setter Property="Margin" Value="5,0,10,0"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ContentPresenter x:Name="HeaderContent"
+                                              Grid.Column="1"
+                                              VerticalAlignment="Center"
+                                              HorizontalAlignment="Left"
+                                              Margin="11,0,0,0"/>
+                                <Path x:Name="SortArrow"
+                                  Data="M0,0 L0,2 L4,6 L8,2 L8,0 L4,4 z"
+                                  Grid.Column="0"
+                                  Margin="0,0,4,0"
+                                  Stretch="Fill"
+                                  Width="7" Height="6"
+                                  Fill="#999999"                                      
+                                  VerticalAlignment="Center"
+                                  RenderTransformOrigin="0.5,0.5"
+                                  Visibility="Collapsed"/>
+                            </Grid>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="SortDirection" Value="Ascending">
+                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0"/>
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="SortArrow" Property="RenderTransform">
+                                        <Setter.Value>
+                                            <RotateTransform Angle="180"/>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Trigger>
+                                <Trigger Property="SortDirection" Value="Descending">
+                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0"/>
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="SortArrow" Property="RenderTransform">
+                                        <Setter.Value>
+                                            <RotateTransform Angle="0"/>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+            <!-- DataGridRow style -->
+            <Style x:Key="RowStyle1" TargetType="DataGridRow">
+                <Setter Property="Background" Value="{Binding BackgroundBrush}"/>
                 <Setter Property="BorderThickness" Value="0.45" />
-                <Setter Property="BorderBrush" Value="#555555" />
+                <Setter Property="BorderBrush" Value="#555555"/>
                 <Style.Triggers>
-                    <Trigger Property="IsSelected" Value="True">
-                        <Setter Property="Background" Value="#555555" />
-                    </Trigger>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="#555555" />
+                        <Setter Property="Background" Value="#434343"/>
+                    </Trigger>
+                    <Trigger Property="IsSelected" Value="True">
+                        <Setter Property="Background" Value="{StaticResource MainBackgroundColor}"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <!--  Cell style  -->
+            <!-- Cell style -->
             <Style x:Key="CellStyle1" TargetType="DataGridCell">
-                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Margin" Value="1" />
                 <Style.Triggers>
                     <Trigger Property="IsSelected" Value="True">
@@ -72,23 +117,44 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <!--  Group Style  -->
+            <!-- Group Style -->
             <Style x:Key="GroupHeaderStyle" TargetType="{x:Type GroupItem}">
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type GroupItem}">
                             <StackPanel>
-                                <TextBlock Text="{Binding Name}" />
-                                <ItemsPresenter />
+                                <TextBlock Text="{Binding Name}"/>
+                                <ItemsPresenter/>
                             </StackPanel>
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
             </Style>
+            <!-- TextBlock style for DataGrid columns -->
+            <Style x:Key="DataGridTextBlockStyle" TargetType="TextBlock">
+                <Setter Property="VerticalAlignment" Value="Center"/>
+                <Setter Property="Margin" Value="10,0,10,0"/>
+                <Setter Property="Foreground">
+                    <Setter.Value>
+                        <MultiBinding Converter="{StaticResource IsGroupToBrushMultiConverter}">
+                            <Binding Path="IsGroup"/>
+                            <Binding Path="HotspotState"/>
+                        </MultiBinding>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsMouseOver}" Value="True">
+                        <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsSelected}" Value="True">
+                        <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
             <Style x:Key="ButtonStyle1" TargetType="{x:Type Button}">
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="#999999" />
+                        <Setter Property="Background" Value="#999999"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -116,30 +182,38 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <!--  Recompute All Button  -->
+        <!-- Recompute All Button -->
         <StackPanel
-            Grid.Row="0"
-            HorizontalAlignment="Left"
-            Orientation="Horizontal">
+        Grid.Row="0"
+        HorizontalAlignment="Left"
+        Orientation="Horizontal">
             <Button
-                Name="RecomputeGraph"
-                Width="Auto"
-                Height="Auto"
-                Margin="2,1,1,10"
-                Padding="5,2,5,2"
-                Click="RecomputeGraph_Click"
-                IsEnabled="{Binding Path=IsRecomputeEnabled}">
-                Force Re-execute
+            Name="RecomputeGraph"
+            Width="Auto"
+            Height="Auto"
+            Margin="2,1,1,10"
+            Padding="5,2,5,2"
+            IsEnabled="{Binding  Path=IsRecomputeEnabled}"
+            Click="RecomputeGraph_Click">
+                Run All
             </Button>
-            <Label Foreground="White">Total Graph Execution Time:</Label>
-            <Label
-                Name="TotalGraphExecutiontimeLabel"
-                Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"
-                Foreground="White" />
+            <Button
+            Name="ExportTimes"
+            Width="Auto"
+            Height="Auto"
+            Margin="2,1,1,10"
+            Padding="5,2,5,2"
+            Click="ExportTimes_Click"
+            IsEnabled="{Binding Path=IsRecomputeEnabled}">
+                Export
+            </Button>
+            <Label Foreground="{StaticResource NodeNameForeground}">Total Graph Execution Time:</Label>
+            <Label Foreground="{StaticResource NodeNameForeground}"
+               FontFamily="{StaticResource ArtifaktElementRegular}"
+               Name="TotalGraphExecutiontimeLabel"
+               Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"/>
         </StackPanel>
-        <!--  Show Hotspots Menu  -->
-        <StackPanel
-            Grid.Row="1"
+        <StackPanel Grid.Row="1"
             HorizontalAlignment="Left"
             Orientation="Horizontal">
             <ToggleButton
@@ -166,7 +240,7 @@
             <TextBox
                 x:Name="MaxValueNumberBox"
                 Style="{StaticResource NumberBoxStyle}"
-                Text="{Binding Path=HotspotMaxValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                Text="{Binding Path=HotspotMaxValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
             <Label
                 Style="{StaticResource SettingsLabelStyle}"
                 Content="Max value"
@@ -174,34 +248,38 @@
         </StackPanel>
         <StackPanel Grid.Row="2">
             <DataGrid
-                x:Name="NodeAnalysisTable"
-                Grid.Row="2"
-                VerticalAlignment="Center"
-                AutoGenerateColumns="False"
-                Background="#353535"
-                CanUserAddRows="False"
-                CanUserResizeColumns="True"
-                CanUserSortColumns="True"
-                FontSize="11"
-                HeadersVisibility="Column"
-                ItemsSource="{Binding Path=ProfiledNodesCollection.View}"
-                ScrollViewer.CanContentScroll="False"
-                ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                ScrollViewer.VerticalScrollBarVisibility="Auto"
-                SelectionChanged="NodeAnalysisTable_SelectionChanged"
-                SelectionMode="Single"
-                SelectionUnit="FullRow"
-                Style="{StaticResource DataGridStyle1}">
+            x:Name="NodeAnalysisTable"
+            Grid.Row="2"                
+            ItemsSource="{Binding Path=ProfiledNodesCollection.View}"                
+            Style="{StaticResource DataGridStyle1}"
+            AutoGenerateColumns="False"
+            CanUserAddRows="False"
+            Background="#353535"
+            FontSize="11"
+            VerticalAlignment="Center"
+            SelectionUnit="FullRow"
+            SelectionMode="Single"
+            ScrollViewer.CanContentScroll="False"
+            ScrollViewer.HorizontalScrollBarVisibility="Auto"
+            ScrollViewer.VerticalScrollBarVisibility="Auto"
+            CanUserResizeColumns="True"
+            CanUserSortColumns="True"
+            HeadersVisibility="Column"
+            SelectionChanged="NodeAnalysisTable_SelectionChanged"
+            PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+            MouseLeave="NodeAnalysisTable_MouseLeave"
+            Sorting="NodeAnalysisTable_Sorting">
                 <DataGrid.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.HeaderTemplate>
                             <DataTemplate>
                                 <StackPanel>
                                     <TextBlock
-                                        Margin="3"
-                                        FontSize="12"
-                                        Foreground="#ffffff"
-                                        Text="{Binding Name}" />
+                                    Margin="3"
+                                    FontFamily="{StaticResource ArtifaktElementRegular}"
+                                    FontSize="12"
+                                    Foreground="{StaticResource NodeNameForeground}"
+                                    Text="{Binding Name}" />
                                 </StackPanel>
                             </DataTemplate>
                         </GroupStyle.HeaderTemplate>
@@ -210,41 +288,50 @@
                 <DataGrid.Columns>
                     <!--  Execution Order  -->
                     <DataGridTextColumn
-                        Width="Auto"
-                        Binding="{Binding Path=ExecutionOrderNumber}"
-                        Header="#"
-                        IsReadOnly="True">
+                    Header="#"
+                    Binding="{Binding Path=ExecutionOrderNumber}"
+                    IsReadOnly="True"
+                    Width="Auto">
                         <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0" />
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}">
+                                <Setter Property="Visibility">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{StaticResource IsGroupToVisibilityMultiConverter}">
+                                            <Binding Path="IsGroup" />
+                                            <Binding Path="GroupGUID" />
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
                     <!--  Node Name  -->
                     <DataGridTextColumn
-                        Width="*"
-                        Binding="{Binding Name}"
-                        Header="Name"
-                        IsReadOnly="True">
+                    Header="Name"
+                    Binding="{Binding Name}"
+                    IsReadOnly="True"
+                    Width="*">
                         <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0" />
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}">
+                                <Setter Property="Margin">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{StaticResource IsGroupToMarginMultiConverter}">
+                                            <Binding Path="IsGroup" />
+                                            <Binding Path="GroupGUID" />
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
                     <!--  Execution Time  -->
                     <DataGridTextColumn
-                        Width="Auto"
-                        Binding="{Binding ExecutionMilliseconds}"
-                        Header="Execution Time (ms)"
-                        IsReadOnly="True">
+                    Header="Execution Time (ms)"
+                    Binding="{Binding ExecutionMilliseconds}"
+                    IsReadOnly="True"
+                    Width="Auto">
                         <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0" />
-                            </Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}" />
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
                 </DataGrid.Columns>

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -1,12 +1,21 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Media;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Utilities;
 using Dynamo.Wpf.Extensions;
+using System.Text.RegularExpressions;
+using System.Windows.Input;
+using System.Globalization;
+using CoreNodeModels.Input;
 
 namespace TuneUp
 {
@@ -73,7 +82,7 @@ namespace TuneUp
             if (selectedNodes.Count() > 0)
             {
                 // Select
-                var command = new DynamoModel.SelectModelCommand(selectedNodes.Select(nm => nm.GUID), ModifierKeys.None);
+                var command = new DynamoModel.SelectModelCommand(selectedNodes.Select(nm => nm.GUID), Dynamo.Utilities.ModifierKeys.None);
                 commandExecutive.ExecuteCommand(command, uniqueId, "TuneUp");
 
                 // Focus on selected
@@ -90,5 +99,34 @@ namespace TuneUp
         {
             (NodeAnalysisTable.DataContext as TuneUpWindowViewModel).ResetProfiling();
         }
+
+        private void HotspotToggleButton_Checked(object sender, RoutedEventArgs e)
+        {
+            var viewModel = NodeAnalysisTable.DataContext as TuneUpWindowViewModel;
+            viewModel.ShowHotspotsEnabled = (sender as ToggleButton).IsChecked == true;
+        }
+
+        private void NumberValidationTextBox(object sender, TextCompositionEventArgs e)
+        {
+            Regex regex = new Regex("[^0-9]+");
+            e.Handled = regex.IsMatch(e.Text);
+        }
     }
+
+    #region Converters
+
+    public class BoolToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return (bool)value ? Visibility.Visible : Visibility.Hidden;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    #endregion
 }

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
+using System.Windows.Input;
 using System.Windows.Media;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
 using Dynamo.Utilities;
 using Dynamo.Wpf.Extensions;
-using System.Text.RegularExpressions;
-using System.Windows.Input;
-using System.Globalization;
-using CoreNodeModels.Input;
 
 namespace TuneUp
 {
@@ -35,6 +34,12 @@ namespace TuneUp
         /// Used to identify the view extension when sending recordable commands.
         /// </summary>
         private string uniqueId;
+
+        /// <summary>
+        /// A flag indicating whether the current selection change in the DataGrid 
+        /// is initiated by the user (true) or programmatically (false).
+        /// </summary>
+        private bool isUserInitiatedSelection = false;
 
         /// <summary>
         /// Since there is no API for height offset comparing to
@@ -67,6 +72,8 @@ namespace TuneUp
 
         private void NodeAnalysisTable_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (!isUserInitiatedSelection) return;
+
             // Get NodeModel(s) that correspond to selected row(s)
             var selectedNodes = new List<NodeModel>();
             foreach (var item in e.AddedItems)
@@ -90,6 +97,24 @@ namespace TuneUp
             }
         }
 
+        /// <summary>
+        /// Handles the PreviewMouseDown event for the NodeAnalysisTable DataGrid.
+        /// Sets a flag to indicate that the selection change is user-initiated.
+        /// </summary>
+        private void NodeAnalysisTable_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            isUserInitiatedSelection = true;
+        }
+
+        /// <summary>
+        /// Handles the MouseLeave event for the NodeAnalysisTable DataGrid.
+        /// Resets the flag to indicate that the selection change is no longer user-initiated.
+        /// </summary>
+        private void NodeAnalysisTable_MouseLeave(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            isUserInitiatedSelection = false;
+        }
+
         internal void Dispose()
         {
             viewLoadedParams.DynamoWindow.SizeChanged -= DynamoWindow_SizeChanged;
@@ -98,6 +123,39 @@ namespace TuneUp
         private void RecomputeGraph_Click(object sender, RoutedEventArgs e)
         {
             (NodeAnalysisTable.DataContext as TuneUpWindowViewModel).ResetProfiling();
+        }
+
+        /// <summary>
+        /// Handles the sorting event for the NodeAnalysisTable DataGrid.
+        /// Updates the SortingOrder property in the view model based on the column header clicked by the user.
+        /// </summary>
+        private void NodeAnalysisTable_Sorting(object sender, DataGridSortingEventArgs e)
+        {
+            var viewModel = NodeAnalysisTable.DataContext as TuneUpWindowViewModel;
+            if (viewModel != null)
+            {
+                viewModel.SortingOrder = e.Column.Header switch
+                {
+                    "#" => "number",
+                    "Name" => "name",
+                    "Execution Time (ms)" => "time",
+                    _ => viewModel.SortingOrder
+                };
+
+                // Set the sorting direction of the datagrid column
+                e.Column.SortDirection = viewModel.SortDirection == ListSortDirection.Descending
+                    ? ListSortDirection.Descending
+                    : ListSortDirection.Ascending;
+
+                // Apply custom sorting to ensure total times are at the bottom
+                viewModel.ApplyCustomSorting();
+                e.Handled = true;
+            }
+        }
+
+        private void ExportTimes_Click(object sender, RoutedEventArgs e)
+        {
+            (NodeAnalysisTable.DataContext as TuneUpWindowViewModel).ExportToCsv();
         }
 
         private void HotspotToggleButton_Checked(object sender, RoutedEventArgs e)
@@ -125,6 +183,75 @@ namespace TuneUp
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             throw new NotSupportedException();
+        }
+    }
+
+    public class IsGroupToMarginMultiConverter : IMultiValueConverter
+    {
+        private static readonly Guid DefaultGuid = Guid.Empty;
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length == 2 &&
+            values[0] is bool isGroup &&
+            values[1] is Guid groupGuid && groupGuid != DefaultGuid)
+            {
+                return isGroup ? new System.Windows.Thickness(0) : new System.Windows.Thickness(30, 0, 0, 0);
+            }
+            return new System.Windows.Thickness(0);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class IsGroupToBrushMultiConverter : IMultiValueConverter
+    {
+        private static readonly SolidColorBrush GroupBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
+        private static readonly SolidColorBrush DefaultBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AAAAAA"));
+        private static readonly SolidColorBrush MinHotspotBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#B7D78C"));
+        private static readonly SolidColorBrush MaxHotspotBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#EB5555"));
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length == 2 && values[0] is bool isGroup && values[1] is ProfiledNodeHotspotState hotspotState)
+            {
+                if (isGroup) return GroupBrush;
+                else if (hotspotState == ProfiledNodeHotspotState.Low) return MinHotspotBrush;
+                else if (hotspotState == ProfiledNodeHotspotState.High) return MaxHotspotBrush;
+            }
+            return DefaultBrush;
+        }
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class IsGroupToVisibilityMultiConverter : IMultiValueConverter
+    {
+        private static readonly Guid DefaultGuid = Guid.Empty;
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length == 2 &&
+                values[0] is bool isGroup &&
+                values[1] is Guid groupGuid)
+            {
+                if (isGroup || groupGuid == DefaultGuid)
+                {
+                    return Visibility.Visible;
+                }
+                return Visibility.Collapsed;
+            }
+            return Visibility.Collapsed;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
         }
     }
 

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -39,6 +39,52 @@ namespace TuneUp
     /// </summary>
     public class TuneUpWindowViewModel : NotificationObject, IDisposable
     {
+        private bool showHotspotsEnabled;
+        private int hotspotMinValue;
+        private int hotspotMaxValue;
+        public bool ShowHotspotsEnabled
+        {
+            get => showHotspotsEnabled;
+            set
+            {
+                showHotspotsEnabled = value;
+                RaisePropertyChanged(nameof(ShowHotspotsEnabled));
+            }
+        }
+        public int HotspotMinValue
+        {
+            get => hotspotMinValue;
+            set
+            {
+                if (hotspotMinValue != value)
+                {
+                    hotspotMinValue = value;
+                    RaisePropertyChanged(nameof(HotspotMinValue));
+                    UpdateNodeBackgrounds();
+                }
+            }
+        }
+        public int HotspotMaxValue
+        {
+            get => hotspotMaxValue;
+            set
+            {
+                if (hotspotMaxValue != value)
+                {
+                    hotspotMaxValue = value;
+                    RaisePropertyChanged(nameof(HotspotMaxValue));
+                    UpdateNodeBackgrounds();
+                }
+            }
+        }
+        private void UpdateNodeBackgrounds()
+        {
+            foreach (var node in nodeDictionary.Values)
+            {
+                node.UpdateHotspotValues(HotspotMinValue, HotspotMaxValue);
+            }
+        }
+
         #region Internal Properties
 
         private ViewLoadedParams viewLoadedParams;
@@ -97,7 +143,7 @@ namespace TuneUp
         #endregion
 
         #region Public Properties
-        
+
         /// <summary>
         /// Is the recomputeAll button enabled in the UI. Users should not be able to force a 
         /// reset of the engine and re-execution of the graph if one is still ongoing. This causes...trouble.
@@ -418,7 +464,7 @@ namespace TuneUp
                     node.NodeExecutionBegin += OnNodeExecutionBegin;
                     node.NodeExecutionEnd += OnNodeExecutionEnd;
                 }
-                ResetProfiledNodes();                
+                ResetProfiledNodes();
             }
             // Unsubscribe to workspace events
             else
@@ -433,7 +479,7 @@ namespace TuneUp
                     node.NodeExecutionBegin -= OnNodeExecutionBegin;
                     node.NodeExecutionEnd -= OnNodeExecutionEnd;
                 }
-            }            
+            }
             executedNodesNum = 0;
         }
 


### PR DESCRIPTION
Proof of concept for https://jira.autodesk.com/browse/DYN-2332

![DYN-2332-Draft](https://github.com/user-attachments/assets/049da689-3a17-4fed-8f7d-0c3c5584f754)

Currently, the `ToggleButton` and controls for this feature are integrated into TuneUp's `DataGrid`. The colors update dynamically.

I wanted to get feedback on the following:

- Is this workflow generally acceptable?
- Has there been any UI/UX design work done for this feature?
- It was mentioned that the goal for TuneUp is to become an out-of-the-box (OOTB) extension for Dynamo. If so, should these controls be moved to Dynamo's Preferences menu? If not, is the current location appropriate?

Thanks!

FYI
@QilongTang
@reddyashish
@Amoursol