### PR TITLE
[DYN-2654] groups of nodes in graph should be displayed as group in tuneup list view

### DIFF
--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -216,7 +216,6 @@ namespace TuneUp
         internal Stopwatch Stopwatch { get; set; }
 
         internal NodeModel NodeModel { get; set; }
-        internal AnnotationModel AnnotationModel { get; set; }
 
         #endregion
 

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -251,7 +251,6 @@ namespace TuneUp
         public ProfiledNodeViewModel(AnnotationModel group)
         {
             NodeModel = null;
-            AnnotationModel = group;
             Name = $"{GroupNodePrefix}{group.AnnotationText}";
             GroupName = group.AnnotationText;
             GroupGUID = group.GUID;

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Windows.Media;
 using Dynamo.Core;
+using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Nodes;
 
 namespace TuneUp
@@ -43,10 +44,7 @@ namespace TuneUp
         /// </summary>
         public int? ExecutionOrderNumber
         {
-            get
-            {
-                return executionOrderNumber;
-            }
+            get => executionOrderNumber;
             set
             {
                 executionOrderNumber = value;
@@ -55,12 +53,13 @@ namespace TuneUp
         }
         private int? executionOrderNumber;
 
+        /// <summary>
+        /// The order number of this group in the most recent graph run.
+        /// This number is assigned to each node within the group.
+        /// </summary>
         public int? GroupExecutionOrderNumber
         {
-            get
-            {
-                return groupExecutionOrderNumber;
-            }
+            get => groupExecutionOrderNumber;
             set
             {
                 groupExecutionOrderNumber = value;
@@ -69,16 +68,12 @@ namespace TuneUp
         }
         private int? groupExecutionOrderNumber;
 
-
         /// <summary>
         /// The most recent execution time of this node
         /// </summary>
         public TimeSpan ExecutionTime
         {
-            get
-            {
-                return executionTime;
-            }
+            get => executionTime;
             set
             {
                 executionTime = value;
@@ -88,12 +83,12 @@ namespace TuneUp
         }
         private TimeSpan executionTime;
 
+        /// <summary>
+        /// The total execution time of all node in the group.
+        /// </summary>
         public TimeSpan GroupExecutionTime
         {
-            get
-            {
-                return groupExecutionTime;
-            }
+            get => groupExecutionTime;
             set
             {
                 groupExecutionTime = value;
@@ -107,10 +102,7 @@ namespace TuneUp
         /// </summary>
         public int ExecutionMilliseconds
         {
-            get
-            {
-                return (int)Math.Round(ExecutionTime.TotalMilliseconds);
-            }
+            get => (int)Math.Round(ExecutionTime.TotalMilliseconds);
         }
 
         /// <summary>
@@ -118,10 +110,7 @@ namespace TuneUp
         /// </summary>
         public bool WasExecutedOnLastRun
         {
-            get
-            {
-                return wasExecutedOnLastRun;
-            }
+            get => wasExecutedOnLastRun;
             set
             {
                 wasExecutedOnLastRun = value;
@@ -135,10 +124,7 @@ namespace TuneUp
         /// </summary>
         public ProfiledNodeState State
         {
-            get
-            {
-                return state;
-            }
+            get => state;
             set
             {
                 state = value;
@@ -147,6 +133,9 @@ namespace TuneUp
         }
         private ProfiledNodeState state;
 
+        /// <summary>
+        /// The GUID of the group to which this node belongs
+        /// </summary>
         public Guid GroupGUID
         {
             get => groupGIUD;
@@ -158,17 +147,10 @@ namespace TuneUp
         }
         private Guid groupGIUD;
 
-        public bool IsGroup
-        {
-            get => isGroup;
-            set
-            {
-                isGroup = value;
-                RaisePropertyChanged(nameof(IsGroup));
-            }
-        }
-        private bool isGroup;
-
+        /// <summary>
+        /// The name of the group to which this node belongs
+        /// This property is also applied to individual nodes and is used when sorting by name
+        /// </summary>
         public string GroupName
         {
             get => groupName;
@@ -180,20 +162,37 @@ namespace TuneUp
         }
         private string groupName;
 
-        public SolidColorBrush GroupNodeBackgroundBrush
+        /// <summary>
+        /// Indicates if this node is a group
+        /// </summary>
+        public bool IsGroup
         {
-            get => groupNodeBackgroundBrush;
+            get => isGroup;
+            set
+            {
+                isGroup = value;
+                RaisePropertyChanged(nameof(IsGroup));
+            }
+        }
+        private bool isGroup;
+
+        /// <summary>
+        /// The background brush for this node
+        /// If this node represents a group, it inherits the background color from the associated AnnotationModel
+        /// </summary>
+        public SolidColorBrush BackgroundBrush
+        {
+            get => backgroundBrush;
             set
             {
                 if (value != null)
                 {
-                    groupNodeBackgroundBrush = value;
-                    RaisePropertyChanged(nameof(GroupNodeBackgroundBrush));
+                    backgroundBrush = value;
+                    RaisePropertyChanged(nameof(BackgroundBrush));
                 }
             }
         }
-        private SolidColorBrush groupNodeBackgroundBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
-
+        private SolidColorBrush backgroundBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
 
         /// <summary>
         /// Return the display name of state enum.
@@ -245,15 +244,19 @@ namespace TuneUp
             State = state;
         }
 
-        // Constructor for ProfiledAnnotationNodes
-        public ProfiledNodeViewModel(string name, SolidColorBrush backgroundBrush)
+        /// <summary>
+        /// An alternative constructor to represent an annotation model as a group node.
+        /// </summary>
+        /// <param name="group">the annotation model</param>
+        public ProfiledNodeViewModel(AnnotationModel group)
         {
             NodeModel = null;
-            this.Name = name;
-            State = ProfiledNodeState.NotExecuted;
-            GroupNodeBackgroundBrush = backgroundBrush;
-            State = state;
+            Name = $"{GroupNodePrefix}{group.AnnotationText}";
+            GroupName = group.AnnotationText;
+            GroupGUID = group.GUID;
+            BackgroundBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString(group.Background));
             IsGroup = true;
+            State = ProfiledNodeState.NotExecuted;
         }
     }
 }

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Windows.Media;
 using Dynamo.Core;
 using Dynamo.Graph.Nodes;
 
@@ -16,6 +17,8 @@ namespace TuneUp
         /// </summary>
         public static readonly string ExecutionTimelString = "Execution Time";
 
+        public static readonly string GroupNodePrefix = "Group:";
+
         private string name = String.Empty;
         /// <summary>
         /// The name of this profiled node. This value can be either an actual
@@ -27,7 +30,7 @@ namespace TuneUp
             get 
             {
                 // For virtual row, do not attempt to grab node name
-                if (!name.Contains(ExecutionTimelString))
+                if (!name.Contains(ExecutionTimelString) && !name.StartsWith(GroupNodePrefix))
                     name = NodeModel?.Name;
                 return name;
             }
@@ -51,6 +54,20 @@ namespace TuneUp
             }
         }
         private int? executionOrderNumber;
+
+        public int? ExecutionGroupOrderNumber
+        {
+            get
+            {
+                return executionGroupOrderNumber;
+            }
+            set
+            {
+                executionGroupOrderNumber = value;
+                RaisePropertyChanged(nameof(ExecutionGroupOrderNumber));
+            }
+        }
+        private int? executionGroupOrderNumber;
 
 
         /// <summary>
@@ -116,6 +133,43 @@ namespace TuneUp
         }
         private ProfiledNodeState state;
 
+        public Guid GroupGUID
+        {
+            get => groupGIUD;
+            set
+            {
+                groupGIUD = value;
+                RaisePropertyChanged(nameof(GroupGUID));
+            }
+        }
+        private Guid groupGIUD;
+
+        public bool IsGroup
+        {
+            get => isGroup;
+            set
+            {
+                isGroup = value;
+                RaisePropertyChanged(nameof(IsGroup));
+            }
+        }
+        private bool isGroup;
+
+        public SolidColorBrush GroupBackgroundBrush
+        {
+            get => groupBackgroundBrush;
+            set
+            {
+                if (value != null)
+                {
+                    groupBackgroundBrush = value;
+                    RaisePropertyChanged(nameof(GroupBackgroundBrush));
+                }
+            }
+        }
+        private SolidColorBrush groupBackgroundBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
+
+
         /// <summary>
         /// Return the display name of state enum.
         /// Making this identical property because of datagrid binding
@@ -164,6 +218,15 @@ namespace TuneUp
             this.Name = name;
             this.ExecutionTime = exTimeSum;
             State = state;
+        }
+
+        // Constructor for ProfiledAnnotationNodes
+        public ProfiledNodeViewModel(string name, SolidColorBrush backgroundBrush)
+        {
+            NodeModel = null;
+            this.Name = name;
+            State = ProfiledNodeState.NotExecuted;
+            GroupBackgroundBrush = backgroundBrush;
         }
     }
 }

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -88,6 +88,21 @@ namespace TuneUp
         }
         private TimeSpan executionTime;
 
+        public TimeSpan GroupExecutionTime
+        {
+            get
+            {
+                return groupExecutionTime;
+            }
+            set
+            {
+                executionTime = value;
+                RaisePropertyChanged(nameof(GroupExecutionTime));
+                RaisePropertyChanged(nameof(ExecutionMilliseconds));
+            }
+        }
+        private TimeSpan groupExecutionTime;
+
         /// <summary>
         /// The most recent execution time of this node in milliseconds
         /// </summary>
@@ -154,6 +169,17 @@ namespace TuneUp
             }
         }
         private bool isGroup;
+
+        public string GroupName
+        {
+            get => groupName;
+            set
+            {
+                groupName = value;
+                RaisePropertyChanged(nameof(GroupName));
+            }
+        }
+        private string groupName;
 
         public SolidColorBrush GroupBackgroundBrush
         {

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -17,7 +17,7 @@ namespace TuneUp
         /// </summary>
         public static readonly string ExecutionTimelString = "Execution Time";
 
-        public static readonly string GroupNodePrefix = "Group:";
+        public static readonly string GroupNodePrefix = "Group: ";
 
         private string name = String.Empty;
         /// <summary>
@@ -55,19 +55,19 @@ namespace TuneUp
         }
         private int? executionOrderNumber;
 
-        public int? ExecutionGroupOrderNumber
+        public int? GroupExecutionOrderNumber
         {
             get
             {
-                return executionGroupOrderNumber;
+                return groupExecutionOrderNumber;
             }
             set
             {
-                executionGroupOrderNumber = value;
-                RaisePropertyChanged(nameof(ExecutionGroupOrderNumber));
+                groupExecutionOrderNumber = value;
+                RaisePropertyChanged(nameof(GroupExecutionOrderNumber));
             }
         }
-        private int? executionGroupOrderNumber;
+        private int? groupExecutionOrderNumber;
 
 
         /// <summary>
@@ -96,9 +96,8 @@ namespace TuneUp
             }
             set
             {
-                executionTime = value;
+                groupExecutionTime = value;
                 RaisePropertyChanged(nameof(GroupExecutionTime));
-                RaisePropertyChanged(nameof(ExecutionMilliseconds));
             }
         }
         private TimeSpan groupExecutionTime;
@@ -181,19 +180,19 @@ namespace TuneUp
         }
         private string groupName;
 
-        public SolidColorBrush GroupBackgroundBrush
+        public SolidColorBrush GroupNodeBackgroundBrush
         {
-            get => groupBackgroundBrush;
+            get => groupNodeBackgroundBrush;
             set
             {
                 if (value != null)
                 {
-                    groupBackgroundBrush = value;
-                    RaisePropertyChanged(nameof(GroupBackgroundBrush));
+                    groupNodeBackgroundBrush = value;
+                    RaisePropertyChanged(nameof(GroupNodeBackgroundBrush));
                 }
             }
         }
-        private SolidColorBrush groupBackgroundBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
+        private SolidColorBrush groupNodeBackgroundBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
 
 
         /// <summary>
@@ -252,7 +251,9 @@ namespace TuneUp
             NodeModel = null;
             this.Name = name;
             State = ProfiledNodeState.NotExecuted;
-            GroupBackgroundBrush = backgroundBrush;
+            GroupNodeBackgroundBrush = backgroundBrush;
+            State = state;
+            IsGroup = true;
         }
     }
 }

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -216,6 +216,7 @@ namespace TuneUp
         internal Stopwatch Stopwatch { get; set; }
 
         internal NodeModel NodeModel { get; set; }
+        internal AnnotationModel AnnotationModel { get; set; }
 
         #endregion
 
@@ -251,6 +252,7 @@ namespace TuneUp
         public ProfiledNodeViewModel(AnnotationModel group)
         {
             NodeModel = null;
+            AnnotationModel = group;
             Name = $"{GroupNodePrefix}{group.AnnotationText}";
             GroupName = group.AnnotationText;
             GroupGUID = group.GUID;

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -20,6 +20,7 @@
             </ResourceDictionary.MergedDictionaries>
             <local:ParentToMarginConverter x:Key="ParentToMarginConverter" />
             <local:IsGroupToBrushConverter x:Key="IsGroupToBrushConverter" />
+            <local:GuidToVisibilityConverter x:Key="GuidToVisibilityConverter"/>
         </ResourceDictionary>
     </Window.Resources>
     <Grid Name="MainGrid">
@@ -206,7 +207,8 @@
                 SelectionChanged="NodeAnalysisTable_SelectionChanged"
                 SelectionMode="Single"
                 SelectionUnit="FullRow"
-                Style="{StaticResource DataGridStyle1}">
+                Style="{StaticResource DataGridStyle1}"
+                Sorting="NodeAnalysisTable_Sorting">
                 <DataGrid.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.HeaderTemplate>
@@ -228,20 +230,31 @@
                     <DataGridTextColumn
                         Width="Auto"
                         Binding="{Binding Path=ExecutionOrderNumber}"
-                        FontFamily="{StaticResource ArtifaktElementRegular}"
-                        Foreground="{StaticResource MemberButtonText}"
                         Header="#"
                         IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
                                 <Setter Property="Margin" Value="10,0,10,0" />
+                                <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
+                                <Setter Property="Visibility" Value="{Binding GroupGUID, Converter={StaticResource GuidToVisibilityConverter}}" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-                    
+                    <!--<DataGridTemplateColumn Width="*" Header="#">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock
+                                    Text="{Binding ExecutionOrderNumber}"
+                                    VerticalAlignment="Center"
+                                    Margin="10,0,10,0"
+                                    Foreground="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}"
+                                    Visibility="{Binding GroupGUID, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>-->
                     <!--  Node Name  -->
-                    <!--<DataGridTextColumn
+                    <DataGridTextColumn
                         Width="*"
                         Binding="{Binding Name}"
                         FontFamily="{StaticResource ArtifaktElementRegular}"
@@ -254,19 +267,31 @@
                                 <Setter Property="Margin" Value="10,0,10,0" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn>-->
-                    <DataGridTemplateColumn Width="*" Header="Name">
+                    </DataGridTextColumn>                    
+                    <!--<DataGridTemplateColumn Width="*" Header="Name">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <TextBlock
-                                    Margin="{Binding ExecutionGroupOrderNumber, Converter={StaticResource ParentToMarginConverter}}"
+                                    Text="{Binding Name}"
                                     VerticalAlignment="Center"
-                                    Foreground="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}"
-                                    Text="{Binding Name}" />
+                                    Margin="{Binding ExecutionGroupOrderNumber, Converter={StaticResource ParentToMarginConverter}}"                                    
+                                    Foreground="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
+                    </DataGridTemplateColumn>-->
+                    
                     <!--  Execution Time  -->
+                    <!--<DataGridTemplateColumn Width="Auto" Header="Execution Time (ms)">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock
+                                    Text="{Binding ExecutionMilliseconds}"
+                                    VerticalAlignment="Center"
+                                    Margin="10,0,10,0"
+                                    Foreground="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}"/>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>-->
                     <DataGridTextColumn
                         Width="Auto"
                         Binding="{Binding ExecutionMilliseconds}"

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -18,10 +18,9 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
-            <local:ParentToMarginMultiConverter  x:Key="ParentToMarginMultiConverter" />
-            <local:ParentToVisibilityMultiConverter  x:Key="ParentToVisibilityMultiConverter" />
+            <local:IsGroupToMarginMultiConverter  x:Key="IsGroupToMarginMultiConverter" />
+            <local:IsGroupToVisibilityMultiConverter  x:Key="IsGroupToVisibilityMultiConverter" />
             <local:IsGroupToBrushConverter x:Key="IsGroupToBrushConverter" />
-            <!--<local:GuidToVisibilityConverter x:Key="GuidToVisibilityConverter"/>-->
         </ResourceDictionary>
     </Window.Resources>
     <Grid Name="MainGrid">
@@ -101,7 +100,7 @@
             </Style>
             <!--  DataGridRow style  -->
             <Style x:Key="RowStyle1" TargetType="DataGridRow">
-                <Setter Property="Background" Value="{Binding GroupNodeBackgroundBrush}" />
+                <Setter Property="Background" Value="{Binding BackgroundBrush}" />
                 <Setter Property="BorderThickness" Value="0.45" />
                 <Setter Property="BorderBrush" Value="#555555" />
                 <Style.Triggers>
@@ -238,10 +237,9 @@
                                 <Setter Property="VerticalAlignment" Value="Center" />
                                 <Setter Property="Margin" Value="10,0,10,0" />
                                 <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
-                                <!--<Setter Property="Visibility" Value="{Binding GroupGUID, Converter={StaticResource GuidToVisibilityConverter}}" />-->
                                 <Setter Property="Visibility">
                                     <Setter.Value>
-                                        <MultiBinding Converter="{StaticResource ParentToVisibilityMultiConverter}">
+                                        <MultiBinding Converter="{StaticResource IsGroupToVisibilityMultiConverter}">
                                             <Binding Path="IsGroup" />
                                             <Binding Path="GroupGUID" />
                                         </MultiBinding>
@@ -260,10 +258,9 @@
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
                                 <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
-                                <!--<Setter Property="Margin" Value="{Binding IsGroup, Converter={StaticResource ParentToMarginConverter}}"/>-->
                                 <Setter Property="Margin">
                                     <Setter.Value>
-                                        <MultiBinding Converter="{StaticResource ParentToMarginMultiConverter}">
+                                        <MultiBinding Converter="{StaticResource IsGroupToMarginMultiConverter}">
                                             <Binding Path="IsGroup" />
                                             <Binding Path="GroupGUID" />
                                         </MultiBinding>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -1,86 +1,94 @@
-﻿<Window x:Class="TuneUp.TuneUpWindow"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:TuneUp"
-             xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
-             xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
-             mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300"
-             Width="500" Height="100">
+﻿<Window
+    x:Class="TuneUp.TuneUpWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:TuneUp"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+    Width="500"
+    Height="100"
+    d:DesignHeight="300"
+    d:DesignWidth="300"
+    mc:Ignorable="d">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
+            <local:ParentToMarginConverter x:Key="ParentToMarginConverter" />
+            <local:IsGroupToBrushConverter x:Key="IsGroupToBrushConverter" />
         </ResourceDictionary>
     </Window.Resources>
-    <Grid Name="MainGrid" >
+    <Grid Name="MainGrid">
         <Grid.Resources>
-            <!-- DataGrid style -->
+            <!--  DataGrid style  -->
             <Style x:Key="DataGridStyle1" TargetType="{x:Type DataGrid}">
-                <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle1}"/>
-                <Setter Property="RowStyle" Value="{DynamicResource RowStyle1}"/>
-                <Setter Property="CellStyle" Value="{DynamicResource CellStyle1}"/>
-                <Setter Property="RowHeaderWidth" Value="0"/>
+                <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle1}" />
+                <Setter Property="RowStyle" Value="{DynamicResource RowStyle1}" />
+                <Setter Property="CellStyle" Value="{DynamicResource CellStyle1}" />
+                <Setter Property="RowHeaderWidth" Value="0" />
                 <Setter Property="BorderThickness" Value="0.5" />
-                <Setter Property="BorderBrush" Value="#555555"/>
-                <Setter Property="ColumnWidth" Value="Auto"/>
-                <Setter Property="GridLinesVisibility" Value="Vertical"/>
-                <Setter Property="VerticalGridLinesBrush" Value="#555555"/>
+                <Setter Property="BorderBrush" Value="#555555" />
+                <Setter Property="ColumnWidth" Value="Auto" />
+                <Setter Property="GridLinesVisibility" Value="Vertical" />
+                <Setter Property="VerticalGridLinesBrush" Value="#555555" />
             </Style>
-            <!-- DataGridColumnHeader style -->
+            <!--  DataGridColumnHeader style  -->
             <Style x:Key="ColumnHeaderStyle1" TargetType="DataGridColumnHeader">
-                <Setter Property="Height" Value="20"/>
-                <Setter Property="Background" Value="#333333"/>
-                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
-                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
-                <Setter Property="FontSize" Value="10"/>
-                <Setter Property="BorderThickness" Value="0"/>
-                <Setter Property="BorderBrush" Value="#555555"/>
-                <Setter Property="Margin" Value="5,0,10,0"/>
+                <Setter Property="Height" Value="20" />
+                <Setter Property="Background" Value="#333333" />
+                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}" />
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
+                <Setter Property="FontSize" Value="10" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="BorderBrush" Value="#555555" />
+                <Setter Property="Margin" Value="5,0,10,0" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
                             <Grid>
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
-                                <ContentPresenter x:Name="HeaderContent"
-                                                  Grid.Column="1"
-                                                  VerticalAlignment="Center"
-                                                  HorizontalAlignment="Left"
-                                                  Margin="11,0,0,0"/>
-                                <Path x:Name="SortArrow"
-                                      Data="M0,0 L0,2 L4,6 L8,2 L8,0 L4,4 z"
-                                      Grid.Column="0"
-                                      Margin="0,0,4,0"
-                                      Stretch="Fill"
-                                      Width="7" Height="6"
-                                      Fill="#999999"                                      
-                                      VerticalAlignment="Center"
-                                      RenderTransformOrigin="0.5,0.5"
-                                      Visibility="Collapsed"/>
+                                <ContentPresenter
+                                    x:Name="HeaderContent"
+                                    Grid.Column="1"
+                                    Margin="11,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center" />
+                                <Path
+                                    x:Name="SortArrow"
+                                    Grid.Column="0"
+                                    Width="7"
+                                    Height="6"
+                                    Margin="0,0,4,0"
+                                    VerticalAlignment="Center"
+                                    Data="M0,0 L0,2 L4,6 L8,2 L8,0 L4,4 z"
+                                    Fill="#999999"
+                                    RenderTransformOrigin="0.5,0.5"
+                                    Stretch="Fill"
+                                    Visibility="Collapsed" />
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="SortDirection" Value="Ascending">
-                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0"/>
-                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0" />
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
                                     <Setter TargetName="SortArrow" Property="RenderTransform">
                                         <Setter.Value>
-                                            <RotateTransform Angle="180"/>
+                                            <RotateTransform Angle="180" />
                                         </Setter.Value>
                                     </Setter>
                                 </Trigger>
                                 <Trigger Property="SortDirection" Value="Descending">
-                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0"/>
-                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0" />
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
                                     <Setter TargetName="SortArrow" Property="RenderTransform">
                                         <Setter.Value>
-                                            <RotateTransform Angle="0"/>
+                                            <RotateTransform Angle="0" />
                                         </Setter.Value>
                                     </Setter>
                                 </Trigger>
@@ -89,11 +97,11 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-            <!-- DataGridRow style -->
+            <!--  DataGridRow style  -->
             <Style x:Key="RowStyle1" TargetType="DataGridRow">
-                <Setter Property="Background" Value="#333333"/>
+                <Setter Property="Background" Value="{Binding GroupBackgroundBrush}" />
                 <Setter Property="BorderThickness" Value="0.45" />
-                <Setter Property="BorderBrush" Value="#555555"/>
+                <Setter Property="BorderBrush" Value="#555555" />
                 <Style.Triggers>
                     <Trigger Property="IsSelected" Value="True">
                         <Setter Property="Background" Value="#555555" />
@@ -103,7 +111,7 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <!-- Cell style -->
+            <!--  Cell style  -->
             <Style x:Key="CellStyle1" TargetType="DataGridCell">
                 <Setter Property="BorderThickness" Value="0" />
                 <Setter Property="Margin" Value="1" />
@@ -113,30 +121,30 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <!-- Group Style -->
+            <!--  Group Style  -->
             <Style x:Key="GroupHeaderStyle" TargetType="{x:Type GroupItem}">
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type GroupItem}">
                             <StackPanel>
-                                <TextBlock Text="{Binding Name}"/>
-                                <ItemsPresenter/>
+                                <TextBlock Text="{Binding Name}" />
+                                <ItemsPresenter />
                             </StackPanel>
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
             </Style>
-            <!-- TextBlock style for DataGrid columns -->
+            <!--  TextBlock style for DataGrid columns  -->
             <Style x:Key="DataGridTextBlockStyle" TargetType="TextBlock">
-                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
-                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
-                <Setter Property="VerticalAlignment" Value="Center"/>
-                <Setter Property="Margin" Value="10,0,10,0"/>
+                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}" />
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Margin" Value="10,0,10,0" />
             </Style>
             <Style x:Key="ButtonStyle1" TargetType="{x:Type Button}">
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="#999999"/>
+                        <Setter Property="Background" Value="#999999" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -145,19 +153,19 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <!-- Recompute All Button -->
-        <StackPanel 
-            Orientation="Horizontal"
+        <!--  Recompute All Button  -->
+        <StackPanel
+            Grid.Row="0"
             HorizontalAlignment="Left"
-            Grid.Row="0">
+            Orientation="Horizontal">
             <Button
                 Name="RecomputeGraph"
                 Width="Auto"
                 Height="Auto"
                 Margin="2,1,1,10"
-                IsEnabled="{Binding  Path=IsRecomputeEnabled}"
+                Padding="5,2,5,2"
                 Click="RecomputeGraph_Click"
-                Padding="5,2,5,2">
+                IsEnabled="{Binding Path=IsRecomputeEnabled}">
                 Run All
             </Button>
             <Button
@@ -166,98 +174,110 @@
                 Height="Auto"
                 Margin="2,1,1,10"
                 Padding="5,2,5,2"
-                IsEnabled="{Binding  Path=IsRecomputeEnabled}"
-                Click="ExportTimes_Click">
+                Click="ExportTimes_Click"
+                IsEnabled="{Binding Path=IsRecomputeEnabled}">
                 Export
             </Button>
             <Label Foreground="{StaticResource NodeNameForeground}">Total Graph Execution Time:</Label>
-            <Label Foreground="{StaticResource NodeNameForeground}"
-                   FontFamily="{StaticResource ArtifaktElementRegular}"
-                   Name="TotalGraphExecutiontimeLabel"
-                   Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"/>
+            <Label
+                Name="TotalGraphExecutiontimeLabel"
+                Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"
+                FontFamily="{StaticResource ArtifaktElementRegular}"
+                Foreground="{StaticResource NodeNameForeground}" />
         </StackPanel>
         <StackPanel Grid.Row="1">
-            <DataGrid 
-            x:Name="NodeAnalysisTable" 
-            Grid.Row="1"
-            ItemsSource="{Binding Path=ProfiledNodesCollection.View}"
-            Style="{StaticResource DataGridStyle1}"
-            AutoGenerateColumns="False"
-            CanUserAddRows="False"
-            Background="#353535"    
-            FontSize="11"
-            VerticalAlignment="Center"
-            SelectionUnit="FullRow"
-            SelectionMode="Single"
-            ScrollViewer.CanContentScroll="False" 
-            ScrollViewer.HorizontalScrollBarVisibility="Auto"
-            ScrollViewer.VerticalScrollBarVisibility="Auto"
-            CanUserResizeColumns="True" 
-            CanUserSortColumns="True"
-            HeadersVisibility="Column"
-            SelectionChanged="NodeAnalysisTable_SelectionChanged"
-            PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
-            MouseLeave="NodeAnalysisTable_MouseLeave" >
+            <DataGrid
+                x:Name="NodeAnalysisTable"
+                Grid.Row="1"
+                VerticalAlignment="Center"
+                AutoGenerateColumns="False"
+                Background="#353535"
+                CanUserAddRows="False"
+                CanUserResizeColumns="True"
+                CanUserSortColumns="True"
+                FontSize="11"
+                HeadersVisibility="Column"
+                ItemsSource="{Binding Path=ProfiledNodesCollection.View}"
+                MouseLeave="NodeAnalysisTable_MouseLeave"
+                PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                ScrollViewer.CanContentScroll="False"
+                ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                ScrollViewer.VerticalScrollBarVisibility="Auto"
+                SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                SelectionMode="Single"
+                SelectionUnit="FullRow"
+                Style="{StaticResource DataGridStyle1}">
                 <DataGrid.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.HeaderTemplate>
                             <DataTemplate>
                                 <StackPanel>
-                                    <TextBlock 
-                                        Text="{Binding Name}"
-                                        Foreground="{StaticResource NodeNameForeground}"
-                                        FontFamily="{StaticResource ArtifaktElementRegular}" 
+                                    <TextBlock
                                         Margin="3"
+                                        FontFamily="{StaticResource ArtifaktElementRegular}"
                                         FontSize="12"
-                                        />
+                                        Foreground="{StaticResource NodeNameForeground}"
+                                        Text="{Binding Name}" />
                                 </StackPanel>
                             </DataTemplate>
                         </GroupStyle.HeaderTemplate>
                     </GroupStyle>
                 </DataGrid.GroupStyle>
                 <DataGrid.Columns>
-                    <!-- Execution Order -->
-                    <DataGridTextColumn 
-                    Header="#" 
-                    Binding="{Binding Path=ExecutionOrderNumber}" 
-                    Foreground="{StaticResource MemberButtonText}"
-                    FontFamily="{StaticResource ArtifaktElementRegular}" 
-                    IsReadOnly="True"
-                    Width="Auto">
+                    <!--  Execution Order  -->
+                    <DataGridTextColumn
+                        Width="Auto"
+                        Binding="{Binding Path=ExecutionOrderNumber}"
+                        FontFamily="{StaticResource ArtifaktElementRegular}"
+                        Foreground="{StaticResource MemberButtonText}"
+                        Header="#"
+                        IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0"/>
+                                <Setter Property="Margin" Value="10,0,10,0" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-                    <!-- Node Name -->
-                    <DataGridTextColumn 
-                    Header="Name" 
-                    Binding="{Binding Name}" 
-                    Foreground="{StaticResource MemberButtonText}"
-                    FontFamily="{StaticResource ArtifaktElementRegular}"
-                    IsReadOnly="True" 
-                    Width="*">
+                    
+                    <!--  Node Name  -->
+                    <!--<DataGridTextColumn
+                        Width="*"
+                        Binding="{Binding Name}"
+                        FontFamily="{StaticResource ArtifaktElementRegular}"
+                        Foreground="{StaticResource MemberButtonText}"
+                        Header="Name"
+                        IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0"/>
+                                <Setter Property="Margin" Value="10,0,10,0" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn>
-                    <!-- Execution Time -->
-                    <DataGridTextColumn 
-                    Header="Execution Time (ms)" 
-                    Binding="{Binding ExecutionMilliseconds}" 
-                    Foreground="{StaticResource MemberButtonText}"
-                    FontFamily="{StaticResource ArtifaktElementRegular}"
-                    IsReadOnly="True" 
-                    Width="Auto">
+                    </DataGridTextColumn>-->
+                    <DataGridTemplateColumn Width="*" Header="Name">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock
+                                    Margin="{Binding ExecutionGroupOrderNumber, Converter={StaticResource ParentToMarginConverter}}"
+                                    VerticalAlignment="Center"
+                                    Foreground="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}"
+                                    Text="{Binding Name}" />
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <!--  Execution Time  -->
+                    <DataGridTextColumn
+                        Width="Auto"
+                        Binding="{Binding ExecutionMilliseconds}"
+                        FontFamily="{StaticResource ArtifaktElementRegular}"
+                        Foreground="{StaticResource MemberButtonText}"
+                        Header="Execution Time (ms)"
+                        IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0"/>
+                                <Setter Property="Margin" Value="10,0,10,0" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -18,9 +18,10 @@
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoColorsAndBrushesDictionaryUri}" />
                 <ui:SharedResourceDictionary Source="{x:Static ui:SharedDictionaryManager.DynamoModernDictionaryUri}" />
             </ResourceDictionary.MergedDictionaries>
-            <local:ParentToMarginConverter x:Key="ParentToMarginConverter" />
+            <local:ParentToMarginMultiConverter  x:Key="ParentToMarginMultiConverter" />
+            <local:ParentToVisibilityMultiConverter  x:Key="ParentToVisibilityMultiConverter" />
             <local:IsGroupToBrushConverter x:Key="IsGroupToBrushConverter" />
-            <local:GuidToVisibilityConverter x:Key="GuidToVisibilityConverter"/>
+            <!--<local:GuidToVisibilityConverter x:Key="GuidToVisibilityConverter"/>-->
         </ResourceDictionary>
     </Window.Resources>
     <Grid Name="MainGrid">
@@ -100,7 +101,7 @@
             </Style>
             <!--  DataGridRow style  -->
             <Style x:Key="RowStyle1" TargetType="DataGridRow">
-                <Setter Property="Background" Value="{Binding GroupBackgroundBrush}" />
+                <Setter Property="Background" Value="{Binding GroupNodeBackgroundBrush}" />
                 <Setter Property="BorderThickness" Value="0.45" />
                 <Setter Property="BorderBrush" Value="#555555" />
                 <Style.Triggers>
@@ -237,71 +238,50 @@
                                 <Setter Property="VerticalAlignment" Value="Center" />
                                 <Setter Property="Margin" Value="10,0,10,0" />
                                 <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
-                                <Setter Property="Visibility" Value="{Binding GroupGUID, Converter={StaticResource GuidToVisibilityConverter}}" />
+                                <!--<Setter Property="Visibility" Value="{Binding GroupGUID, Converter={StaticResource GuidToVisibilityConverter}}" />-->
+                                <Setter Property="Visibility">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{StaticResource ParentToVisibilityMultiConverter}">
+                                            <Binding Path="IsGroup" />
+                                            <Binding Path="GroupGUID" />
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
-                    <!--<DataGridTemplateColumn Width="*" Header="#">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock
-                                    Text="{Binding ExecutionOrderNumber}"
-                                    VerticalAlignment="Center"
-                                    Margin="10,0,10,0"
-                                    Foreground="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}"
-                                    Visibility="{Binding GroupGUID, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>-->
                     <!--  Node Name  -->
                     <DataGridTextColumn
                         Width="*"
                         Binding="{Binding Name}"
-                        FontFamily="{StaticResource ArtifaktElementRegular}"
-                        Foreground="{StaticResource MemberButtonText}"
                         Header="Name"
                         IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0" />
+                                <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
+                                <!--<Setter Property="Margin" Value="{Binding IsGroup, Converter={StaticResource ParentToMarginConverter}}"/>-->
+                                <Setter Property="Margin">
+                                    <Setter.Value>
+                                        <MultiBinding Converter="{StaticResource ParentToMarginMultiConverter}">
+                                            <Binding Path="IsGroup" />
+                                            <Binding Path="GroupGUID" />
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn>                    
-                    <!--<DataGridTemplateColumn Width="*" Header="Name">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock
-                                    Text="{Binding Name}"
-                                    VerticalAlignment="Center"
-                                    Margin="{Binding ExecutionGroupOrderNumber, Converter={StaticResource ParentToMarginConverter}}"                                    
-                                    Foreground="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>-->
-                    
+                    </DataGridTextColumn> 
                     <!--  Execution Time  -->
-                    <!--<DataGridTemplateColumn Width="Auto" Header="Execution Time (ms)">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock
-                                    Text="{Binding ExecutionMilliseconds}"
-                                    VerticalAlignment="Center"
-                                    Margin="10,0,10,0"
-                                    Foreground="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}"/>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>-->
                     <DataGridTextColumn
                         Width="Auto"
                         Binding="{Binding ExecutionMilliseconds}"
-                        FontFamily="{StaticResource ArtifaktElementRegular}"
-                        Foreground="{StaticResource MemberButtonText}"
                         Header="Execution Time (ms)"
                         IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock">
                                 <Setter Property="VerticalAlignment" Value="Center" />
+                                <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
                                 <Setter Property="Margin" Value="10,0,10,0" />
                             </Style>
                         </DataGridTextColumn.ElementStyle>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -167,7 +167,7 @@
             Margin="2,1,1,10"
             Padding="5,2,5,2"
             IsEnabled="{Binding  Path=IsRecomputeEnabled}"
-            Click="ExportTimes_Click">
+            Click="RecomputeGraph_Click">
                 Run All
             </Button>
             <Button

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -101,14 +101,14 @@
             <!--  DataGridRow style  -->
             <Style x:Key="RowStyle1" TargetType="DataGridRow">
                 <Setter Property="Background" Value="{Binding BackgroundBrush}" />
-                <Setter Property="BorderThickness" Value="0.45" />
+                <Setter Property="BorderThickness" Value="0" />
                 <Setter Property="BorderBrush" Value="#555555" />
                 <Style.Triggers>
-                    <Trigger Property="IsSelected" Value="True">
-                        <Setter Property="Background" Value="#555555" />
-                    </Trigger>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="#555555" />
+                        <Setter Property="Background" Value="#434343" />
+                    </Trigger>
+                    <Trigger Property="IsSelected" Value="True">
+                        <Setter Property="Background" Value="{StaticResource MainBackgroundColor}" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -135,12 +135,19 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-            <!--  TextBlock style for DataGrid columns  -->
+            <!-- TextBlock style for DataGrid columns -->
             <Style x:Key="DataGridTextBlockStyle" TargetType="TextBlock">
-                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}" />
-                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
                 <Setter Property="VerticalAlignment" Value="Center" />
                 <Setter Property="Margin" Value="10,0,10,0" />
+                <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsMouseOver}" Value="True">
+                        <Setter Property="Foreground" Value="{StaticResource MemberButtonText}" />
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsSelected}" Value="True">
+                        <Setter Property="Foreground" Value="{StaticResource MemberButtonText}" />
+                    </DataTrigger>
+                </Style.Triggers>
             </Style>
             <Style x:Key="ButtonStyle1" TargetType="{x:Type Button}">
                 <Style.Triggers>
@@ -233,10 +240,7 @@
                         Header="#"
                         IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0" />
-                                <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}">
                                 <Setter Property="Visibility">
                                     <Setter.Value>
                                         <MultiBinding Converter="{StaticResource IsGroupToVisibilityMultiConverter}">
@@ -255,9 +259,7 @@
                         Header="Name"
                         IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}">
                                 <Setter Property="Margin">
                                     <Setter.Value>
                                         <MultiBinding Converter="{StaticResource IsGroupToMarginMultiConverter}">
@@ -268,7 +270,7 @@
                                 </Setter>
                             </Style>
                         </DataGridTextColumn.ElementStyle>
-                    </DataGridTextColumn> 
+                    </DataGridTextColumn>
                     <!--  Execution Time  -->
                     <DataGridTextColumn
                         Width="Auto"
@@ -276,11 +278,7 @@
                         Header="Execution Time (ms)"
                         IsReadOnly="True">
                         <DataGridTextColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
-                                <Setter Property="Margin" Value="10,0,10,0" />
-                            </Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}" />
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
                 </DataGrid.Columns>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -1,17 +1,14 @@
-﻿<Window
-    x:Class="TuneUp.TuneUpWindow"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="clr-namespace:TuneUp"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
-    Width="500"
-    Height="100"
-    d:DesignHeight="300"
-    d:DesignWidth="300"
-    mc:Ignorable="d">
+﻿ ﻿<Window x:Class="TuneUp.TuneUpWindow"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:TuneUp"
+             xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+             xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+             mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300"
+             Width="500" Height="100">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -23,44 +20,44 @@
             <local:IsGroupToBrushConverter x:Key="IsGroupToBrushConverter" />
         </ResourceDictionary>
     </Window.Resources>
-    <Grid Name="MainGrid">
+    <Grid Name="MainGrid" >
         <Grid.Resources>
-            <!--  DataGrid style  -->
+            <!-- DataGrid style -->
             <Style x:Key="DataGridStyle1" TargetType="{x:Type DataGrid}">
-                <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle1}" />
-                <Setter Property="RowStyle" Value="{DynamicResource RowStyle1}" />
-                <Setter Property="CellStyle" Value="{DynamicResource CellStyle1}" />
-                <Setter Property="RowHeaderWidth" Value="0" />
-                <Setter Property="BorderThickness" Value="0.5" />
-                <Setter Property="BorderBrush" Value="#555555" />
-                <Setter Property="ColumnWidth" Value="Auto" />
-                <Setter Property="GridLinesVisibility" Value="Vertical" />
-                <Setter Property="VerticalGridLinesBrush" Value="#555555" />
+                <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle1}"/>
+                <Setter Property="RowStyle" Value="{DynamicResource RowStyle1}"/>
+                <Setter Property="CellStyle" Value="{DynamicResource CellStyle1}"/>
+                <Setter Property="RowHeaderWidth" Value="0"/>
+                <Setter Property="BorderThickness" Value="0.5"/>
+                <Setter Property="BorderBrush" Value="#555555"/>
+                <Setter Property="ColumnWidth" Value="Auto"/>
+                <Setter Property="GridLinesVisibility" Value="Vertical"/>
+                <Setter Property="VerticalGridLinesBrush" Value="#555555"/>
             </Style>
-            <!--  DataGridColumnHeader style  -->
+            <!-- DataGridColumnHeader style -->
             <Style x:Key="ColumnHeaderStyle1" TargetType="DataGridColumnHeader">
                 <Setter Property="Height" Value="20" />
                 <Setter Property="Background" Value="#333333" />
-                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}" />
-                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
-                <Setter Property="FontSize" Value="10" />
-                <Setter Property="BorderThickness" Value="0" />
-                <Setter Property="BorderBrush" Value="#555555" />
-                <Setter Property="Margin" Value="5,0,10,0" />
+                <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
+                <Setter Property="FontSize" Value="10"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="BorderBrush" Value="#555555"/>
+                <Setter Property="Margin" Value="5,0,10,0"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
                             <Grid>
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
                                 <ContentPresenter
                                     x:Name="HeaderContent"
                                     Grid.Column="1"
                                     Margin="11,0,0,0"
                                     HorizontalAlignment="Left"
-                                    VerticalAlignment="Center" />
+                                    VerticalAlignment="Center"/>
                                 <Path
                                     x:Name="SortArrow"
                                     Grid.Column="0"
@@ -72,21 +69,21 @@
                                     Fill="#999999"
                                     RenderTransformOrigin="0.5,0.5"
                                     Stretch="Fill"
-                                    Visibility="Collapsed" />
+                                    Visibility="Collapsed"/>
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="SortDirection" Value="Ascending">
-                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0" />
-                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
+                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0"/>
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
                                     <Setter TargetName="SortArrow" Property="RenderTransform">
                                         <Setter.Value>
-                                            <RotateTransform Angle="180" />
+                                            <RotateTransform Angle="180"/>
                                         </Setter.Value>
                                     </Setter>
                                 </Trigger>
                                 <Trigger Property="SortDirection" Value="Descending">
-                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0" />
-                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
+                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0"/>
+                                    <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
                                     <Setter TargetName="SortArrow" Property="RenderTransform">
                                         <Setter.Value>
                                             <RotateTransform Angle="0" />
@@ -98,38 +95,38 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-            <!--  DataGridRow style  -->
+            <!-- DataGridRow style -->
             <Style x:Key="RowStyle1" TargetType="DataGridRow">
-                <Setter Property="Background" Value="{Binding BackgroundBrush}" />
-                <Setter Property="BorderThickness" Value="0" />
-                <Setter Property="BorderBrush" Value="#555555" />
+                <Setter Property="Background" Value="{Binding BackgroundBrush}"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="BorderBrush" Value="#555555"/>
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="#434343" />
+                        <Setter Property="Background" Value="#434343"/>
                     </Trigger>
                     <Trigger Property="IsSelected" Value="True">
-                        <Setter Property="Background" Value="{StaticResource MainBackgroundColor}" />
+                        <Setter Property="Background" Value="{StaticResource MainBackgroundColor}"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <!--  Cell style  -->
+            <!-- Cell style -->
             <Style x:Key="CellStyle1" TargetType="DataGridCell">
-                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Margin" Value="1" />
                 <Style.Triggers>
                     <Trigger Property="IsSelected" Value="True">
-                        <Setter Property="Background" Value="#555555" />
+                        <Setter Property="Background" Value="#555555"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <!--  Group Style  -->
+            <!-- Group Style -->
             <Style x:Key="GroupHeaderStyle" TargetType="{x:Type GroupItem}">
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type GroupItem}">
                             <StackPanel>
-                                <TextBlock Text="{Binding Name}" />
-                                <ItemsPresenter />
+                                <TextBlock Text="{Binding Name}"/>
+                                <ItemsPresenter/>
                             </StackPanel>
                         </ControlTemplate>
                     </Setter.Value>
@@ -137,15 +134,15 @@
             </Style>
             <!-- TextBlock style for DataGrid columns -->
             <Style x:Key="DataGridTextBlockStyle" TargetType="TextBlock">
-                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="VerticalAlignment" Value="Center"/>
                 <Setter Property="Margin" Value="10,0,10,0" />
-                <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}" />
+                <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}"/>
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsMouseOver}" Value="True">
-                        <Setter Property="Foreground" Value="{StaticResource MemberButtonText}" />
+                        <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
                     </DataTrigger>
                     <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsSelected}" Value="True">
-                        <Setter Property="Foreground" Value="{StaticResource MemberButtonText}" />
+                        <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
@@ -161,7 +158,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <!--  Recompute All Button  -->
+        <!-- Recompute All Button -->
         <StackPanel
             Grid.Row="0"
             HorizontalAlignment="Left"
@@ -172,8 +169,8 @@
                 Height="Auto"
                 Margin="2,1,1,10"
                 Padding="5,2,5,2"
-                Click="RecomputeGraph_Click"
-                IsEnabled="{Binding Path=IsRecomputeEnabled}">
+                IsEnabled="{Binding  Path=IsRecomputeEnabled}"
+                Click="ExportTimes_Click">
                 Run All
             </Button>
             <Button
@@ -187,34 +184,33 @@
                 Export
             </Button>
             <Label Foreground="{StaticResource NodeNameForeground}">Total Graph Execution Time:</Label>
-            <Label
-                Name="TotalGraphExecutiontimeLabel"
-                Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"
-                FontFamily="{StaticResource ArtifaktElementRegular}"
-                Foreground="{StaticResource NodeNameForeground}" />
+            <Label Foreground="{StaticResource NodeNameForeground}"
+                   FontFamily="{StaticResource ArtifaktElementRegular}"
+                   Name="TotalGraphExecutiontimeLabel"
+                   Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"/>
         </StackPanel>
         <StackPanel Grid.Row="1">
             <DataGrid
                 x:Name="NodeAnalysisTable"
-                Grid.Row="1"
-                VerticalAlignment="Center"
+                Grid.Row="1"                
+                ItemsSource="{Binding Path=ProfiledNodesCollection.View}"                
+                Style="{StaticResource DataGridStyle1}"
                 AutoGenerateColumns="False"
-                Background="#353535"
                 CanUserAddRows="False"
-                CanUserResizeColumns="True"
-                CanUserSortColumns="True"
+                Background="#353535"
                 FontSize="11"
-                HeadersVisibility="Column"
-                ItemsSource="{Binding Path=ProfiledNodesCollection.View}"
-                MouseLeave="NodeAnalysisTable_MouseLeave"
-                PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                VerticalAlignment="Center"
+                SelectionUnit="FullRow"
+                SelectionMode="Single"
                 ScrollViewer.CanContentScroll="False"
                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                CanUserResizeColumns="True"
+                CanUserSortColumns="True"
+                HeadersVisibility="Column"
                 SelectionChanged="NodeAnalysisTable_SelectionChanged"
-                SelectionMode="Single"
-                SelectionUnit="FullRow"
-                Style="{StaticResource DataGridStyle1}"
+                PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                MouseLeave="NodeAnalysisTable_MouseLeave"
                 Sorting="NodeAnalysisTable_Sorting">
                 <DataGrid.GroupStyle>
                     <GroupStyle>
@@ -235,10 +231,10 @@
                 <DataGrid.Columns>
                     <!--  Execution Order  -->
                     <DataGridTextColumn
-                        Width="Auto"
-                        Binding="{Binding Path=ExecutionOrderNumber}"
                         Header="#"
-                        IsReadOnly="True">
+                        Binding="{Binding Path=ExecutionOrderNumber}"
+                        IsReadOnly="True"
+                        Width="Auto">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}">
                                 <Setter Property="Visibility">
@@ -254,10 +250,10 @@
                     </DataGridTextColumn>
                     <!--  Node Name  -->
                     <DataGridTextColumn
-                        Width="*"
-                        Binding="{Binding Name}"
                         Header="Name"
-                        IsReadOnly="True">
+                        Binding="{Binding Name}"
+                        IsReadOnly="True"
+                        Width="*">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}">
                                 <Setter Property="Margin">
@@ -273,10 +269,10 @@
                     </DataGridTextColumn>
                     <!--  Execution Time  -->
                     <DataGridTextColumn
-                        Width="Auto"
-                        Binding="{Binding ExecutionMilliseconds}"
                         Header="Execution Time (ms)"
-                        IsReadOnly="True">
+                        Binding="{Binding ExecutionMilliseconds}"
+                        IsReadOnly="True"
+                        Width="Auto">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}" />
                         </DataGridTextColumn.ElementStyle>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -1,14 +1,14 @@
-﻿ ﻿<Window x:Class="TuneUp.TuneUpWindow"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:TuneUp"
-             xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
-             xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
-             mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300"
-             Width="500" Height="100">
+﻿<Window x:Class="TuneUp.TuneUpWindow"
+         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+         xmlns:local="clr-namespace:TuneUp"
+         xmlns:ui="clr-namespace:Dynamo.UI;assembly=DynamoCoreWpf"
+         xmlns:componentmodel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
+         mc:Ignorable="d" 
+         d:DesignHeight="300" d:DesignWidth="300"
+         Width="500" Height="100">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -28,7 +28,7 @@
                 <Setter Property="RowStyle" Value="{DynamicResource RowStyle1}"/>
                 <Setter Property="CellStyle" Value="{DynamicResource CellStyle1}"/>
                 <Setter Property="RowHeaderWidth" Value="0"/>
-                <Setter Property="BorderThickness" Value="0.5"/>
+                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="#555555"/>
                 <Setter Property="ColumnWidth" Value="Auto"/>
                 <Setter Property="GridLinesVisibility" Value="Vertical"/>
@@ -36,8 +36,8 @@
             </Style>
             <!-- DataGridColumnHeader style -->
             <Style x:Key="ColumnHeaderStyle1" TargetType="DataGridColumnHeader">
-                <Setter Property="Height" Value="20" />
-                <Setter Property="Background" Value="#333333" />
+                <Setter Property="Height" Value="20"/>
+                <Setter Property="Background" Value="#333333"/>
                 <Setter Property="Foreground" Value="{StaticResource MemberButtonText}"/>
                 <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}"/>
                 <Setter Property="FontSize" Value="10"/>
@@ -52,24 +52,21 @@
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <ContentPresenter
-                                    x:Name="HeaderContent"
-                                    Grid.Column="1"
-                                    Margin="11,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"/>
-                                <Path
-                                    x:Name="SortArrow"
-                                    Grid.Column="0"
-                                    Width="7"
-                                    Height="6"
-                                    Margin="0,0,4,0"
-                                    VerticalAlignment="Center"
-                                    Data="M0,0 L0,2 L4,6 L8,2 L8,0 L4,4 z"
-                                    Fill="#999999"
-                                    RenderTransformOrigin="0.5,0.5"
-                                    Stretch="Fill"
-                                    Visibility="Collapsed"/>
+                                <ContentPresenter x:Name="HeaderContent"
+                                              Grid.Column="1"
+                                              VerticalAlignment="Center"
+                                              HorizontalAlignment="Left"
+                                              Margin="11,0,0,0"/>
+                                <Path x:Name="SortArrow"
+                                  Data="M0,0 L0,2 L4,6 L8,2 L8,0 L4,4 z"
+                                  Grid.Column="0"
+                                  Margin="0,0,4,0"
+                                  Stretch="Fill"
+                                  Width="7" Height="6"
+                                  Fill="#999999"                                      
+                                  VerticalAlignment="Center"
+                                  RenderTransformOrigin="0.5,0.5"
+                                  Visibility="Collapsed"/>
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="SortDirection" Value="Ascending">
@@ -86,7 +83,7 @@
                                     <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
                                     <Setter TargetName="SortArrow" Property="RenderTransform">
                                         <Setter.Value>
-                                            <RotateTransform Angle="0" />
+                                            <RotateTransform Angle="0"/>
                                         </Setter.Value>
                                     </Setter>
                                 </Trigger>
@@ -98,7 +95,7 @@
             <!-- DataGridRow style -->
             <Style x:Key="RowStyle1" TargetType="DataGridRow">
                 <Setter Property="Background" Value="{Binding BackgroundBrush}"/>
-                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="BorderThickness" Value="0.45" />
                 <Setter Property="BorderBrush" Value="#555555"/>
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
@@ -115,7 +112,7 @@
                 <Setter Property="Margin" Value="1" />
                 <Style.Triggers>
                     <Trigger Property="IsSelected" Value="True">
-                        <Setter Property="Background" Value="#555555"/>
+                        <Setter Property="Background" Value="#555555" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -135,7 +132,7 @@
             <!-- TextBlock style for DataGrid columns -->
             <Style x:Key="DataGridTextBlockStyle" TargetType="TextBlock">
                 <Setter Property="VerticalAlignment" Value="Center"/>
-                <Setter Property="Margin" Value="10,0,10,0" />
+                <Setter Property="Margin" Value="10,0,10,0"/>
                 <Setter Property="Foreground" Value="{Binding IsGroup, Converter={StaticResource IsGroupToBrushConverter}}"/>
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsMouseOver}" Value="True">
@@ -149,7 +146,7 @@
             <Style x:Key="ButtonStyle1" TargetType="{x:Type Button}">
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
-                        <Setter Property="Background" Value="#999999" />
+                        <Setter Property="Background" Value="#999999"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -160,69 +157,69 @@
         </Grid.RowDefinitions>
         <!-- Recompute All Button -->
         <StackPanel
-            Grid.Row="0"
-            HorizontalAlignment="Left"
-            Orientation="Horizontal">
+        Grid.Row="0"
+        HorizontalAlignment="Left"
+        Orientation="Horizontal">
             <Button
-                Name="RecomputeGraph"
-                Width="Auto"
-                Height="Auto"
-                Margin="2,1,1,10"
-                Padding="5,2,5,2"
-                IsEnabled="{Binding  Path=IsRecomputeEnabled}"
-                Click="ExportTimes_Click">
+            Name="RecomputeGraph"
+            Width="Auto"
+            Height="Auto"
+            Margin="2,1,1,10"
+            Padding="5,2,5,2"
+            IsEnabled="{Binding  Path=IsRecomputeEnabled}"
+            Click="ExportTimes_Click">
                 Run All
             </Button>
             <Button
-                Name="ExportTimes"
-                Width="Auto"
-                Height="Auto"
-                Margin="2,1,1,10"
-                Padding="5,2,5,2"
-                Click="ExportTimes_Click"
-                IsEnabled="{Binding Path=IsRecomputeEnabled}">
+            Name="ExportTimes"
+            Width="Auto"
+            Height="Auto"
+            Margin="2,1,1,10"
+            Padding="5,2,5,2"
+            Click="ExportTimes_Click"
+            IsEnabled="{Binding Path=IsRecomputeEnabled}">
                 Export
             </Button>
             <Label Foreground="{StaticResource NodeNameForeground}">Total Graph Execution Time:</Label>
             <Label Foreground="{StaticResource NodeNameForeground}"
-                   FontFamily="{StaticResource ArtifaktElementRegular}"
-                   Name="TotalGraphExecutiontimeLabel"
-                   Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"/>
+               FontFamily="{StaticResource ArtifaktElementRegular}"
+               Name="TotalGraphExecutiontimeLabel"
+               Content="{Binding Path=TotalGraphExecutiontime, Mode=OneWay}"/>
         </StackPanel>
         <StackPanel Grid.Row="1">
             <DataGrid
-                x:Name="NodeAnalysisTable"
-                Grid.Row="1"                
-                ItemsSource="{Binding Path=ProfiledNodesCollection.View}"                
-                Style="{StaticResource DataGridStyle1}"
-                AutoGenerateColumns="False"
-                CanUserAddRows="False"
-                Background="#353535"
-                FontSize="11"
-                VerticalAlignment="Center"
-                SelectionUnit="FullRow"
-                SelectionMode="Single"
-                ScrollViewer.CanContentScroll="False"
-                ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                ScrollViewer.VerticalScrollBarVisibility="Auto"
-                CanUserResizeColumns="True"
-                CanUserSortColumns="True"
-                HeadersVisibility="Column"
-                SelectionChanged="NodeAnalysisTable_SelectionChanged"
-                PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
-                MouseLeave="NodeAnalysisTable_MouseLeave"
-                Sorting="NodeAnalysisTable_Sorting">
+            x:Name="NodeAnalysisTable"
+            Grid.Row="1"                
+            ItemsSource="{Binding Path=ProfiledNodesCollection.View}"                
+            Style="{StaticResource DataGridStyle1}"
+            AutoGenerateColumns="False"
+            CanUserAddRows="False"
+            Background="#353535"
+            FontSize="11"
+            VerticalAlignment="Center"
+            SelectionUnit="FullRow"
+            SelectionMode="Single"
+            ScrollViewer.CanContentScroll="False"
+            ScrollViewer.HorizontalScrollBarVisibility="Auto"
+            ScrollViewer.VerticalScrollBarVisibility="Auto"
+            CanUserResizeColumns="True"
+            CanUserSortColumns="True"
+            HeadersVisibility="Column"
+            SelectionChanged="NodeAnalysisTable_SelectionChanged"
+            PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+            MouseLeave="NodeAnalysisTable_MouseLeave"
+            Sorting="NodeAnalysisTable_Sorting">
                 <DataGrid.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.HeaderTemplate>
                             <DataTemplate>
                                 <StackPanel>
                                     <TextBlock
-                                        Margin="3"
-                                        FontFamily="{StaticResource ArtifaktElementRegular}"
-                                        FontSize="12"
-                                        Foreground="{StaticResource NodeNameForeground}"
-                                        Text="{Binding Name}" />
+                                    Margin="3"
+                                    FontFamily="{StaticResource ArtifaktElementRegular}"
+                                    FontSize="12"
+                                    Foreground="{StaticResource NodeNameForeground}"
+                                    Text="{Binding Name}" />
                                 </StackPanel>
                             </DataTemplate>
                         </GroupStyle.HeaderTemplate>
@@ -231,10 +228,10 @@
                 <DataGrid.Columns>
                     <!--  Execution Order  -->
                     <DataGridTextColumn
-                        Header="#"
-                        Binding="{Binding Path=ExecutionOrderNumber}"
-                        IsReadOnly="True"
-                        Width="Auto">
+                    Header="#"
+                    Binding="{Binding Path=ExecutionOrderNumber}"
+                    IsReadOnly="True"
+                    Width="Auto">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}">
                                 <Setter Property="Visibility">
@@ -250,10 +247,10 @@
                     </DataGridTextColumn>
                     <!--  Node Name  -->
                     <DataGridTextColumn
-                        Header="Name"
-                        Binding="{Binding Name}"
-                        IsReadOnly="True"
-                        Width="*">
+                    Header="Name"
+                    Binding="{Binding Name}"
+                    IsReadOnly="True"
+                    Width="*">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}">
                                 <Setter Property="Margin">
@@ -269,10 +266,10 @@
                     </DataGridTextColumn>
                     <!--  Execution Time  -->
                     <DataGridTextColumn
-                        Header="Execution Time (ms)"
-                        Binding="{Binding ExecutionMilliseconds}"
-                        IsReadOnly="True"
-                        Width="Auto">
+                    Header="Execution Time (ms)"
+                    Binding="{Binding ExecutionMilliseconds}"
+                    IsReadOnly="True"
+                    Width="Auto">
                         <DataGridTextColumn.ElementStyle>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource DataGridTextBlockStyle}" />
                         </DataGridTextColumn.ElementStyle>

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
@@ -152,4 +155,45 @@ namespace TuneUp
             (NodeAnalysisTable.DataContext as TuneUpWindowViewModel).ExportToCsv();
         }
     }
+
+    #region Converters
+
+    public class ParentToMarginConverter : IValueConverter
+    {
+        private static readonly Guid DefaultGuid = Guid.Empty;
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+
+            //return value > 0 ? new System.Windows.Thickness(30, 0, 0, 0) : new System.Windows.Thickness(0, 0, 0, 0);
+
+            if (value is int intValue && intValue != 0)
+            {
+                return new System.Windows.Thickness(30, 0, 0, 0);
+            }
+            return new System.Windows.Thickness(0, 0, 0, 0);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+    public class IsGroupToBrushConverter : IValueConverter
+    {
+        private static readonly Guid DefaultGuid = Guid.Empty;
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            bool boolValue = (bool)value;
+            return boolValue ? new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333")) : new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AAAAAA"));
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    #endregion
 }

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -145,47 +145,9 @@ namespace TuneUp
                     : ListSortDirection.Ascending;
 
                 // Apply custom sorting to ensure total times are at the bottom
-                viewModel.ApplySorting();
+                viewModel.ApplyCustomSorting();
                 e.Handled = true;
             }
-
-            //var dataView = CollectionViewSource.GetDefaultView(NodeAnalysisTable.ItemsSource);
-            //ListSortDirection direction;
-
-            //// Determine the new sort direction
-            //if (e.Column.SortDirection == null || e.Column.SortDirection == ListSortDirection.Descending)
-            //{
-            //    direction = ListSortDirection.Ascending;
-            //}
-            //else
-            //{
-            //    direction = ListSortDirection.Descending;
-            //}
-
-            //// Clear previous sort descriptions
-            //dataView.SortDescriptions.Clear();
-
-            //// Apply new sort description based on the column being sorted
-            //if (e.Column.Header.ToString() == "Execution Time (ms)")
-            //{
-            //    dataView.SortDescriptions.Add(new SortDescription("ExecutionMilliseconds", direction));
-            //}
-            //else if (e.Column.Header.ToString() == "Name")
-            //{
-            //    dataView.SortDescriptions.Add(new SortDescription("Name", direction));
-            //}
-            //else if (e.Column.Header.ToString() == "#")
-            //{
-            //    dataView.SortDescriptions.Add(new SortDescription("ExecutionOrderNumber", direction));
-            //}
-
-            //// Refresh the view to apply the sort
-            //dataView.Refresh();
-            //e.Column.SortDirection = direction;
-
-            //// Mark the event as handled
-            //e.Handled = true;
-
         }
 
         private void ExportTimes_Click(object sender, RoutedEventArgs e)
@@ -198,32 +160,41 @@ namespace TuneUp
 
 
     // TODO: Rename Converters!
-    public class ParentToMarginConverter : IValueConverter
+
+    public class ParentToMarginMultiConverter : IMultiValueConverter
     {
         private static readonly Guid DefaultGuid = Guid.Empty;
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is int intValue && intValue != 0)
+            if (values.Length == 2 &&
+                values[0] is bool isGroup &&
+                values[1] is Guid groupGuid)
             {
+                if (isGroup || groupGuid == DefaultGuid)
+                {
+                    return new System.Windows.Thickness(0, 0, 0, 0);
+                }
                 return new System.Windows.Thickness(30, 0, 0, 0);
             }
-            return new System.Windows.Thickness(0, 0, 0, 0);
+            return new System.Windows.Thickness(30, 0, 0, 0);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }
     }
+
     public class IsGroupToBrushConverter : IValueConverter
     {
-        private static readonly Guid DefaultGuid = Guid.Empty;
-
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            bool boolValue = (bool)value;
-            return boolValue ? new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333")) : new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AAAAAA"));
+            if (value is bool isGroup)
+            {
+                return isGroup ? new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333")) : new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AAAAAA"));
+            }
+            return new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -232,20 +203,26 @@ namespace TuneUp
         }
     }
 
-    public class GuidToVisibilityConverter : IValueConverter
+    public class ParentToVisibilityMultiConverter : IMultiValueConverter
     {
         private static readonly Guid DefaultGuid = Guid.Empty;
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is Guid guidValue && guidValue != DefaultGuid)
+            if (values.Length == 2 &&
+                values[0] is bool isGroup &&
+                values[1] is Guid groupGuid)
             {
+                if (isGroup || groupGuid == DefaultGuid)
+                {
+                    return Visibility.Visible;
+                }
                 return Visibility.Collapsed;
             }
-            return Visibility.Visible;
+            return Visibility.Collapsed;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -128,63 +128,63 @@ namespace TuneUp
         /// </summary>
         private void NodeAnalysisTable_Sorting(object sender, DataGridSortingEventArgs e)
         {
-            //var viewModel = NodeAnalysisTable.DataContext as TuneUpWindowViewModel;
-            //if (viewModel != null)
+            var viewModel = NodeAnalysisTable.DataContext as TuneUpWindowViewModel;
+            if (viewModel != null)
+            {
+                viewModel.SortingOrder = e.Column.Header switch
+                {
+                    "#" => "number",
+                    "Name" => "name",
+                    "Execution Time (ms)" => "time",
+                    _ => viewModel.SortingOrder
+                };
+
+                // Set the sorting direction of the datagrid column
+                e.Column.SortDirection = viewModel.SortDirection == ListSortDirection.Descending
+                    ? ListSortDirection.Descending
+                    : ListSortDirection.Ascending;
+
+                // Apply custom sorting to ensure total times are at the bottom
+                viewModel.ApplySorting();
+                e.Handled = true;
+            }
+
+            //var dataView = CollectionViewSource.GetDefaultView(NodeAnalysisTable.ItemsSource);
+            //ListSortDirection direction;
+
+            //// Determine the new sort direction
+            //if (e.Column.SortDirection == null || e.Column.SortDirection == ListSortDirection.Descending)
             //{
-            //    viewModel.SortingOrder = e.Column.Header switch
-            //    {
-            //        "#" => "number",
-            //        "Name" => "name",
-            //        "Execution Time (ms)" => "time",
-            //        _ => viewModel.SortingOrder
-            //    };
-
-            //    // Set the sorting direction of the datagrid column
-            //    e.Column.SortDirection = viewModel.SortDirection == ListSortDirection.Descending
-            //        ? ListSortDirection.Descending
-            //        : ListSortDirection.Ascending;
-
-            //    // Apply custom sorting to ensure total times are at the bottom
-            //    viewModel.ApplySorting();
-            //    e.Handled = true;
+            //    direction = ListSortDirection.Ascending;
+            //}
+            //else
+            //{
+            //    direction = ListSortDirection.Descending;
             //}
 
-            var dataView = CollectionViewSource.GetDefaultView(NodeAnalysisTable.ItemsSource);
-            ListSortDirection direction;
+            //// Clear previous sort descriptions
+            //dataView.SortDescriptions.Clear();
 
-            // Determine the new sort direction
-            if (e.Column.SortDirection == null || e.Column.SortDirection == ListSortDirection.Descending)
-            {
-                direction = ListSortDirection.Ascending;
-            }
-            else
-            {
-                direction = ListSortDirection.Descending;
-            }
+            //// Apply new sort description based on the column being sorted
+            //if (e.Column.Header.ToString() == "Execution Time (ms)")
+            //{
+            //    dataView.SortDescriptions.Add(new SortDescription("ExecutionMilliseconds", direction));
+            //}
+            //else if (e.Column.Header.ToString() == "Name")
+            //{
+            //    dataView.SortDescriptions.Add(new SortDescription("Name", direction));
+            //}
+            //else if (e.Column.Header.ToString() == "#")
+            //{
+            //    dataView.SortDescriptions.Add(new SortDescription("ExecutionOrderNumber", direction));
+            //}
 
-            // Clear previous sort descriptions
-            dataView.SortDescriptions.Clear();
+            //// Refresh the view to apply the sort
+            //dataView.Refresh();
+            //e.Column.SortDirection = direction;
 
-            // Apply new sort description based on the column being sorted
-            if (e.Column.Header.ToString() == "Execution Time (ms)")
-            {
-                dataView.SortDescriptions.Add(new SortDescription("ExecutionMilliseconds", direction));
-            }
-            else if (e.Column.Header.ToString() == "Name")
-            {
-                dataView.SortDescriptions.Add(new SortDescription("Name", direction));
-            }
-            else if (e.Column.Header.ToString() == "#")
-            {
-                dataView.SortDescriptions.Add(new SortDescription("ExecutionOrderNumber", direction));
-            }
-
-            // Refresh the view to apply the sort
-            dataView.Refresh();
-            e.Column.SortDirection = direction;
-
-            // Mark the event as handled
-            e.Handled = true;
+            //// Mark the event as handled
+            //e.Handled = true;
 
         }
 

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -158,26 +158,19 @@ namespace TuneUp
 
     #region Converters
 
-
-    // TODO: Rename Converters!
-
-    public class ParentToMarginMultiConverter : IMultiValueConverter
+    public class IsGroupToMarginMultiConverter : IMultiValueConverter
     {
         private static readonly Guid DefaultGuid = Guid.Empty;
 
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             if (values.Length == 2 &&
-                values[0] is bool isGroup &&
-                values[1] is Guid groupGuid)
+            values[0] is bool isGroup &&
+            values[1] is Guid groupGuid && groupGuid != DefaultGuid)
             {
-                if (isGroup || groupGuid == DefaultGuid)
-                {
-                    return new System.Windows.Thickness(0, 0, 0, 0);
-                }
-                return new System.Windows.Thickness(30, 0, 0, 0);
+                return isGroup ? new System.Windows.Thickness(0) : new System.Windows.Thickness(30, 0, 0, 0);
             }
-            return new System.Windows.Thickness(30, 0, 0, 0);
+            return new System.Windows.Thickness(0);
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
@@ -188,13 +181,12 @@ namespace TuneUp
 
     public class IsGroupToBrushConverter : IValueConverter
     {
+        private static readonly SolidColorBrush GroupBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
+        private static readonly SolidColorBrush DefaultBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AAAAAA"));
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is bool isGroup)
-            {
-                return isGroup ? new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333")) : new SolidColorBrush((Color)ColorConverter.ConvertFromString("#AAAAAA"));
-            }
-            return new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
+            return value is bool isGroup && isGroup ? GroupBrush : DefaultBrush;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
@@ -203,7 +195,7 @@ namespace TuneUp
         }
     }
 
-    public class ParentToVisibilityMultiConverter : IMultiValueConverter
+    public class IsGroupToVisibilityMultiConverter : IMultiValueConverter
     {
         private static readonly Guid DefaultGuid = Guid.Empty;
 

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -302,7 +302,6 @@ namespace TuneUp
             ApplyDefaultSorting();
             ProfiledNodesCollection.View?.Refresh();
 
-            // Notify property changes
             RaisePropertyChanged(nameof(ProfiledNodesCollection));
             RaisePropertyChanged(nameof(ProfiledNodes));
             RaisePropertyChanged(nameof(TotalGraphExecutiontime));
@@ -483,8 +482,7 @@ namespace TuneUp
                     profiledNode.GroupExecutionOrderNumber = groupExecutionCounter++;
                     profiledNode.GroupExecutionTime = profiledNode.ExecutionTime;
                 }
-            }            
-            //RaisePropertyChanged(nameof(ProfiledNodes));
+            }
         }
 
         /// <summary>
@@ -681,7 +679,6 @@ namespace TuneUp
                 workspace.EvaluationCompleted += CurrentWorkspaceModel_EvaluationCompleted;
                 workspace.AnnotationAdded += CurrentWorkspaceModel_GroupAdded;
                 workspace.AnnotationRemoved += CurrentWorkspaceModel_GroupRemoved;
-
 
                 foreach (var node in workspace.Nodes)
                 {

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -274,12 +274,6 @@ namespace TuneUp
                             GroupGUID = group.GUID,
                             GroupName = group.AnnotationText
                         };
-
-                        // Record the profiledNode in nodeDictionary
-                        //if (!nodeDictionary.ContainsKey(node.GUID))                     //!!!!!!!!!!!!!!!!
-                        //{
-                        //    nodeDictionary[node.GUID] = profiledNode;
-                        //}
                         nodeDictionary[node.GUID] = profiledNode;
                         ProfiledNodes.Add(profiledNode);
                         groupDictionary[group.GUID].Add(profiledNode);
@@ -490,7 +484,7 @@ namespace TuneUp
                     profiledNode.GroupExecutionTime = profiledNode.ExecutionTime;
                 }
             }            
-            RaisePropertyChanged(nameof(ProfiledNodes));
+            //RaisePropertyChanged(nameof(ProfiledNodes));
         }
 
         /// <summary>
@@ -631,19 +625,21 @@ namespace TuneUp
             }
 
             // Reset grouped nodes' properties and remove them from groupDictionary
-    if (groupDictionary.TryGetValue(groupGUID, out var groupedNodes))
-    {
-        foreach (var profiledNode in groupedNodes)
-        {
-            profiledNode.GroupGUID = Guid.Empty;
-            profiledNode.GroupName = string.Empty;
-            profiledNode.GroupExecutionOrderNumber = 0;
-            profiledNode.GroupExecutionTime = TimeSpan.Zero;
-        }
-        groupDictionary.Remove(groupGUID);
-    }
-
-    // Notify property changes
+            if (groupDictionary.TryGetValue(groupGUID, out var groupedNodes))
+            {
+                foreach (var profiledNode in groupedNodes)
+                {
+                    profiledNode.GroupGUID = Guid.Empty;
+                    profiledNode.GroupName = string.Empty;
+                    // Immediately after the group is removed, the node's execution order should not
+                    // be displayed, but the nodes will remain in the same location in the DataGrid.
+                    // The execution order will update correctly on the next graph execution.
+                    profiledNode.ExecutionOrderNumber = null;
+                    profiledNode.GroupExecutionTime = TimeSpan.Zero;
+                }
+                groupDictionary.Remove(groupGUID);
+            }
+            
             RaisePropertyChanged(nameof(ProfiledNodesCollection));
             RaisePropertyChanged(nameof(ProfiledNodes));
         }


### PR DESCRIPTION
**_Aims_** to address https://jira.autodesk.com/browse/DYN-2654 🤞

![DYN-2654_PR](https://github.com/user-attachments/assets/7bda593f-3f6c-4c56-a12c-748cab95f7fe)


Displays Groups in TuneUp:

- Each grouped node is indented and positioned under the group header, regardless of the sorting order.
- Sorting can be based on total group execution time, group execution order, or group name.
- When sorting by execution order, if a group is removed, the execution order of the previously grouped nodes will not display, but the nodes will remain in the same location.
- When nodes are grouped, TuneUp will display the group and place the nodes under the header.
- The group will initially have its default name. If the name is changed, TuneUp will update it on the next graph run.
- If the color is changed, TuneUp will update it the next time the graph is loaded.

Hope that's okay.
