### PR TITLE
[DYN-7334] Improvements following the feedback

### DIFF
--- a/TuneUp/TuneUpViewExtension.cs
+++ b/TuneUp/TuneUpViewExtension.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Windows.Controls;
 using Dynamo.Wpf.Extensions;
+using Dynamo.Wpf.Properties;
 
 namespace TuneUp
 {
@@ -62,11 +63,7 @@ namespace TuneUp
 
             // Add this view extension's menu item to the Extensions tab or View tab accordingly.
             var dynamoMenuItems = p.dynamoMenu.Items.OfType<MenuItem>();
-            // TODO: Investigate why TuneUpMenuItem is not added to the specified MenuItem
-            // When _Extensions is specified, TuneUpMenuItem goes to the View menu in Dynamo 3.0-
-            // and does not appear in Dynamo 3.1+.
-            // We need to specify _View for TuneUpMenuItem to be added to the Extensions menu
-            var extensionsMenuItem = dynamoMenuItems.Where(item => item.Header.ToString() == "_View");
+            var extensionsMenuItem = dynamoMenuItems.Where(item => item.Header.ToString() == Resources.DynamoViewExtensionsMenu);
 
             if (extensionsMenuItem.Count() > 0)
             {

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -444,7 +444,10 @@
                               x:Name="LatestRunTable"
                               Style="{StaticResource DataGridStyleTuneUpCombined}"
                               AlternatingRowBackground="#434343"
-                              Sorting="LatestRunTable_Sorting">
+                              Sorting="LatestRunTable_Sorting"
+                              SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                              PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                              MouseLeave="NodeAnalysisTable_MouseLeave">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
                             <DataGridTextColumn Width="40"
@@ -493,7 +496,10 @@
                               Style="{StaticResource DataGridStyleTuneUpCombined}"
                               AlternatingRowBackground="#434343"
                               HeadersVisibility="None"
-                              Sorting="LatestRunTable_Sorting">
+                              Sorting="LatestRunTable_Sorting"
+                              SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                              PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                              MouseLeave="NodeAnalysisTable_MouseLeave">
                         <DataGrid.Columns>
                             <!--Execution Order-->
                             <DataGridTextColumn Width="40"
@@ -540,7 +546,10 @@
                               AlternatingRowBackground="#434343"
                               HeadersVisibility="None"
                               CanUserSortColumns="False"
-                              Sorting="NotExecutedTable_Sorting">                       
+                              Sorting="NotExecutedTable_Sorting"
+                              SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                              PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                              MouseLeave="NodeAnalysisTable_MouseLeave">                       
                         <DataGrid.Columns>
                             <!--Execution Order-->
                             <DataGridTextColumn Width="40"/>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -21,12 +21,12 @@
             <local:IsGroupToMarginMultiConverter x:Key="IsGroupToMarginMultiConverter" />
             <local:IsGroupToVisibilityMultiConverter x:Key="IsGroupToVisibilityMultiConverter" />
             <local:ExecutionOrderNumberVisibilityConverter x:Key="ExecutionOrderNumberVisibilityConverter" />
-            <local:IsGroupToColorBrushConverter x:Key="IsGroupToColorBrushConverter" />
             <local:IsGroupToColorBrushMultiConverter x:Key="IsGroupToColorBrushMultiConverter" />
             <local:IsInGroupToColorBrushMultiConverter x:Key="IsInGroupToColorBrushMultiConverter" />
             <local:IsRenamedToVisibilityMultiConverter x:Key="IsRenamedToVisibilityMultiConverter" />
             <local:ExecutionOrderNumberConverter x:Key="ExecutionOrderNumberConverter" />
             <local:ContainsStringConverter x:Key="ContainsStringConverter" />
+            <local:IsGroupAndBackgroundToForegroundConverter x:Key="IsGroupAndBackgroundToForegroundConverter" />
             <!--  ERROR : DYNAMO CRASHES WHEN REFERENCED FROM DYNAMOCOREWPF  -->
             <Color x:Key="BorderColorTuneUp">#555555</Color>
             <SolidColorBrush x:Key="BorderColorBrushTuneUp" Color="{StaticResource BorderColorTuneUp}" />
@@ -211,7 +211,10 @@
                                 </MultiBinding>
                             </TextBlock.Margin>
                             <TextBlock.Foreground>
-                                <Binding Converter="{StaticResource IsGroupToColorBrushConverter}" Path="IsGroup" />
+                                <MultiBinding Converter="{StaticResource IsGroupAndBackgroundToForegroundConverter}">
+                                    <Binding Path="IsGroup" />
+                                    <Binding Path="BackgroundBrush" />
+                                </MultiBinding>
                             </TextBlock.Foreground>
                         </TextBlock>
                     </Border>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -27,7 +27,6 @@
             <local:IsRenamedToVisibilityMultiConverter x:Key="IsRenamedToVisibilityMultiConverter" />
             <local:ExecutionOrderNumberConverter x:Key="ExecutionOrderNumberConverter" />
             <local:ContainsStringConverter x:Key="ContainsStringConverter" />
-            
             <!--  ERROR : DYNAMO CRASHES WHEN REFERENCED FROM DYNAMOCOREWPF  -->
             <Color x:Key="BorderColorTuneUp">#555555</Color>
             <SolidColorBrush x:Key="BorderColorBrushTuneUp" Color="{StaticResource BorderColorTuneUp}" />
@@ -71,37 +70,33 @@
                 <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
                 <Setter Property="FontSize" Value="10" />
                 <Setter Property="BorderThickness" Value="0" />
-                <Setter Property="Margin" Value="5,0,7,0" />
+                <Setter Property="Margin" Value="5,0,5,0" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <ContentPresenter
-                                    x:Name="HeaderContent"
-                                    Grid.Column="1"
-                                    Margin="11,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center" />
+                            <DockPanel LastChildFill="False" HorizontalAlignment="Left">
+                                <!-- Sort Arrow -->
                                 <Path
                                     x:Name="SortArrow"
-                                    Grid.Column="0"
                                     Width="7"
                                     Height="6"
-                                    Margin="0,0,4,0"
+                                    Margin="5,0,0,0"
                                     VerticalAlignment="Center"
                                     Data="M0,0 L0,2 L4,6 L8,2 L8,0 L4,4 z"
                                     Fill="{StaticResource UnSelectedLayoutForeground}"
                                     RenderTransformOrigin="0.5,0.5"
                                     Stretch="Fill"
-                                    Visibility="Collapsed" />
-                            </Grid>
+                                    Visibility="Collapsed"
+                                    DockPanel.Dock="Right" />
+                                <!-- Header Content -->
+                                <ContentPresenter
+                                    x:Name="HeaderContent"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    DockPanel.Dock="Left" />
+                            </DockPanel>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="SortDirection" Value="Ascending">
-                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0" />
                                     <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
                                     <Setter TargetName="SortArrow" Property="RenderTransform">
                                         <Setter.Value>
@@ -110,7 +105,6 @@
                                     </Setter>
                                 </Trigger>
                                 <Trigger Property="SortDirection" Value="Descending">
-                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0" />
                                     <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
                                     <Setter TargetName="SortArrow" Property="RenderTransform">
                                         <Setter.Value>
@@ -149,7 +143,7 @@
             <!--  TextBlock style for DataGrid columns  -->
             <Style x:Key="DataGridTextBlockStyle" TargetType="TextBlock">
                 <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="Margin" Value="10,0,10,0" />
+                <Setter Property="Margin" Value="6,0,5,0" />
                 <Setter Property="Foreground" Value="{StaticResource DarkThemeBodyMediumBrush}" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsMouseOver}" Value="True">
@@ -176,12 +170,12 @@
             <DataTemplate x:Key="NodeNameTemplate">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="7" />
+                        <ColumnDefinition Width="8" />
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" MinWidth="8" />
                     </Grid.ColumnDefinitions>
                     <!-- Group indicator -->
-                    <Border Grid.Column="0" Margin="4,0,0,0">
+                    <Border Grid.Column="0" Margin="5,0,0,0">
                         <Border.Background>
                             <MultiBinding Converter="{StaticResource IsInGroupToColorBrushMultiConverter}" Mode="OneWay">
                                 <Binding Path="IsGroup" />
@@ -242,7 +236,7 @@
                             <ToolTip Style="{StaticResource GenericToolTipLight}">
                                 <TextBlock>
                                     <TextBlock.Text>
-                                        <Binding Path="OriginalName" StringFormat="Node original name:&#x0a;{0}" />
+                                        <Binding Path="OriginalName" StringFormat="Original node name:&#x0a;{0}" />
                                     </TextBlock.Text>
                                 </TextBlock>
                             </ToolTip>
@@ -284,16 +278,15 @@
             <!-- TextBlock style for collection footer -->
             <Style x:Key="CollectionFooterTextBlockStyle" TargetType="TextBlock">
                 <Setter Property="Height" Value="20"/>
-                <Setter Property="Width" Value="120"/>
-                <Setter Property="Margin" Value="10,0,0,0"/>
                 <Setter Property="FontSize" Value="12"/>
-                <Setter Property="Padding" Value="10,0,0,0"/>
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementBold}"/>
             </Style>
             <!-- TextBlock style for collection header -->
             <Style x:Key="CollectionHeaderTextBlockStyle" TargetType="TextBlock">
                 <Setter Property="Height" Value="20"/>
                 <Setter Property="FontSize" Value="12"/>
                 <Setter Property="Margin" Value="5,0,0,0"/>
+                <Setter Property="FontWeight" Value="Normal"/>
             </Style>
             <!--  Button style *** -->
             <!-- PackageManager\Controls\ControlColorsAndBrushes -->
@@ -391,9 +384,9 @@
                 <TextBlock Width="70"
                            Margin="5,0,0,0"
                            Text="Total"
-                           FontWeight="Bold"/>
+                           FontFamily="{StaticResource ArtifaktElementBold}"/>
                 <TextBlock Text="{Binding Path=TotalGraphExecutionTime, Mode=OneWay}"
-                           FontWeight="Bold"/>
+                           FontFamily="{StaticResource ArtifaktElementBold}"/>
             </StackPanel>
         </StackPanel>
         <!--  Show Groups Button  -->
@@ -409,17 +402,17 @@
                           IsChecked="{Binding ShowGroups, Mode=TwoWay}"
                           IsEnabled="True"
                           Style="{StaticResource EllipseToggleButton1}" />
-            <TextBlock Margin="5,0,0,0"
+            <TextBlock Margin="5,0,7,0"
                        Text="Show groups">
             </TextBlock>
-            <Rectangle Width="16"
+            <!--<Rectangle Width="16"
                        Height="16"
                        Margin="10,0,7,0"
                        VerticalAlignment="Center">
                 <Rectangle.Fill>
                     <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/help-16px.png" />
                 </Rectangle.Fill>
-            </Rectangle>
+            </Rectangle>-->
         </StackPanel>
         <!--  Run All Button  -->
         <Button Grid.Row="1"
@@ -444,7 +437,7 @@
             <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <StackPanel >
                     <!-- Latest Run -->
-                    <TextBlock Text="Latest Run"
+                    <TextBlock Text="Latest run"
                                Style="{StaticResource CollectionHeaderTextBlockStyle}"
                                Visibility="{Binding LatestRunTableVisibility}"/>
                     <DataGrid ItemsSource="{Binding Path=ProfiledNodesCollectionLatestRun.View}"
@@ -472,7 +465,7 @@
                             <!--  Execution Time  -->
                             <DataGridTextColumn Width="120"
                                                 Binding="{Binding ExecutionMilliseconds}"
-                                                Header="Execution Time (ms)"
+                                                Header="Execution time (ms)"
                                                 IsReadOnly="True">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style BasedOn="{StaticResource ExecutionTimeTextBlockStyle}" TargetType="TextBlock"/>
@@ -483,12 +476,16 @@
                     <StackPanel Style="{StaticResource CollectionFooterStackPanelStyle}"
                                 Visibility="{Binding LatestRunTableVisibility}">
                         <TextBlock Text="Total"
-                                   Style="{StaticResource CollectionHeaderTextBlockStyle}"/>
-                        <TextBlock Text="{Binding Path=LatestGraphExecutionTime, Mode=OneWay}"
                                    Style="{StaticResource CollectionFooterTextBlockStyle}"/>
+                        <TextBlock Text="{Binding Path=LatestGraphExecutionTime, Mode=OneWay}"
+                                   Style="{StaticResource CollectionFooterTextBlockStyle}"
+                                   Width="120"
+                                   HorizontalAlignment="Left"
+                                   Margin="10,0,0,0"
+                                   Padding="7,0,0,0"/>
                     </StackPanel>
                     <!-- Previous Run -->
-                    <TextBlock Text="Previous Run"
+                    <TextBlock Text="Previous run"
                                Style="{StaticResource CollectionHeaderTextBlockStyle}"
                                Visibility="{Binding PreviousRunTableVisibility}"/>
                     <DataGrid ItemsSource="{Binding Path=ProfiledNodesCollectionPreviousRun.View}"
@@ -524,12 +521,16 @@
                     <StackPanel Style="{StaticResource CollectionFooterStackPanelStyle}"
                                 Visibility="{Binding PreviousRunTableVisibility}">
                         <TextBlock Text="Total"
-                                   Style="{StaticResource CollectionHeaderTextBlockStyle}"/>
+                                   Style="{StaticResource CollectionFooterTextBlockStyle}"/>
                         <TextBlock Text="{Binding Path=PreviousGraphExecutionTime, Mode=OneWay}"
-                                   Style="{StaticResource CollectionFooterTextBlockStyle}" />
+                                   Style="{StaticResource CollectionFooterTextBlockStyle}"
+                                   Width="120"
+                                   HorizontalAlignment="Left"
+                                   Margin="10,0,0,0"
+                                   Padding="7,0,0,0"/>
                     </StackPanel>
                     <!-- Not Executed -->
-                    <TextBlock Text="Not Executed"
+                    <TextBlock Text="Not executed"
                                Style="{StaticResource CollectionHeaderTextBlockStyle}"
                                Visibility="{Binding NotExecutedTableVisibility}"/>
                     <DataGrid ItemsSource="{Binding Path=ProfiledNodesCollectionNotExecuted.View}"

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Media;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
+using Dynamo.UI;
 using Dynamo.Utilities;
 using Dynamo.Wpf.Extensions;
 
@@ -222,21 +223,56 @@ namespace TuneUp
         }
     }
 
-    public class IsGroupToColorBrushConverter : IValueConverter
+    public class IsGroupAndBackgroundToForegroundConverter : IMultiValueConverter
     {
-        private static readonly SolidColorBrush GroupBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
-        private static readonly SolidColorBrush DarkThemeBodyMediumBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#F5F5F5"));
+        private static readonly SolidColorBrush LightBrush = new SolidColorBrush((Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["WhiteColor"]);
+        private static readonly SolidColorBrush DarkBrush = new SolidColorBrush((Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["DarkerGrey"]);
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            return value is bool isGroup && isGroup ? GroupBrush : DarkThemeBodyMediumBrush;
+            if (values.Length != 2 ||
+                !(values[0] is bool isGroup) ||
+                !(values[1] is SolidColorBrush backgroundBrush))
+            {
+                return LightBrush;
+            }
+
+            if (!isGroup)
+            {
+                return LightBrush;
+            }
+            var backgroundColor = backgroundBrush.Color;
+            var contrastRatio = GetContrastRatio((Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["DarkerGrey"], backgroundColor);
+
+            return contrastRatio < 4.5 ? LightBrush : DarkBrush;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }
-    }    
+
+        private double GetContrastRatio(Color foreground, Color background)
+        {
+            double L1 = GetRelativeLuminance(foreground);
+            double L2 = GetRelativeLuminance(background);
+
+            return L1 > L2 ? (L1 + 0.05) / (L2 + 0.05) : (L2 + 0.05) / (L1 + 0.05);
+        }
+
+        private double GetRelativeLuminance(Color color)
+        {
+            var R = color.R / 255.0;
+            var G = color.G / 255.0;
+            var B = color.B / 255.0;
+
+            R = R < 0.03928 ? R / 12.92 : Math.Pow((R + 0.055) / 1.055, 2.4);
+            G = G < 0.03928 ? G / 12.92 : Math.Pow((G + 0.055) / 1.055, 2.4);
+            B = B < 0.03928 ? B / 12.92 : Math.Pow((B + 0.055) / 1.055, 2.4);
+
+            return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+        }
+    }
 
     public class IsGroupToVisibilityMultiConverter : IMultiValueConverter
     {

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -165,7 +165,7 @@ namespace TuneUp
             {
                 if ( isGroup || !groupGuid.Equals(DefaultGuid)) return new System.Windows.Thickness(5,0,0,0);
             }
-            return new System.Windows.Thickness(-4,0,0,0);
+            return new System.Windows.Thickness(-3,0,0,0);
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)


### PR DESCRIPTION
This PR aims to address some of the resent feedback on TuneUp's revised control layout.  It covers all points from column "3.3" of [Mural](https://app.mural.co/t/autodesk2145/m/autodesk2145/1726671147065/f22bbd9296463ee3376ffd3c5be0a9e68028b323?sender=u63a4c10277115ad8dc555082)  with the exception of point 3.
1.  Hepl icon removed
2.  Centers on node when selected in the TuneUp's UI
3.  
4.  Show TuneUp is present in the Extensions menu even when language is not English
5.  UI changes to match the intended design
6. Group title foreground color auto-adjusts for contrast with the background similarly to the groups in the workspace
7. Jagged edges removed from group nodes

![image](https://github.com/user-attachments/assets/684536c0-9bef-4f6f-9cca-1e76189be551)

![image](https://github.com/user-attachments/assets/bc235bce-e487-4c10-a3d3-34c4bbbc02a3)

![image](https://github.com/user-attachments/assets/2c5ad1cc-a172-4a44-8748-e7c2dfd69a74)

![CenterOnNodeWhenSelected](https://github.com/user-attachments/assets/15e3103f-d2ff-4868-868f-b7c35ac9f3f9)

@QilongTang 
@reddyashish 

@Amoursol 
@dnenov