### PR TITLE
[DYN-7334] Improvements after feedback - part 2

### DIFF
--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -71,44 +71,7 @@ namespace TuneUp
                 RaisePropertyChanged(nameof(IsGroupExecutionTime));
             }
         }
-        private bool isGroupExecutionTime = false;
-
-        /// <summary>
-        /// Getting the original name before graph author renamed the node
-        /// </summary>
-        /// <param name="node">target NodeModel</param>
-        /// <returns>Original node name as string</returns>
-        private static string GetOriginalName(NodeModel node)
-        {
-            if (node == null) return string.Empty;
-            // For dummy node, return the current name so that does not appear to be renamed
-            if (node is DummyNode)
-            {
-                return node.Name;
-            }
-            if (node.IsCustomFunction)
-            {
-                // If the custom node is not loaded, return the current name so that does not appear to be renamed
-                if ((node as Function).State == ElementState.Error && (node as Function).Definition.IsProxy)
-                {
-                    return node.Name;
-                }
-                // If the custom node is loaded, return original name as usual
-                var customNodeFunction = node as Function;
-                return customNodeFunction?.Definition.DisplayName;
-            }
-
-            var function = node as DSFunctionBase;
-            if (function != null)
-                return function.Controller.Definition.DisplayName;
-
-            var nodeType = node.GetType();
-            var elNameAttrib = nodeType.GetCustomAttributes<NodeNameAttribute>(false).FirstOrDefault();
-            if (elNameAttrib != null)
-                return elNameAttrib.Name;
-
-            return nodeType.FullName;
-        }
+        private bool isGroupExecutionTime = false;        
 
         /// <summary>
         /// Prefix string of execution time.
@@ -335,6 +298,59 @@ namespace TuneUp
         internal NodeModel NodeModel { get; set; }
 
         #endregion
+
+        /// <summary>
+        /// Getting the original name before graph author renamed the node
+        /// </summary>
+        /// <param name="node">target NodeModel</param>
+        /// <returns>Original node name as string</returns>
+        private static string GetOriginalName(NodeModel node)
+        {
+            if (node == null) return string.Empty;
+            // For dummy node, return the current name so that does not appear to be renamed
+            if (node is DummyNode)
+            {
+                return node.Name;
+            }
+            if (node.IsCustomFunction)
+            {
+                // If the custom node is not loaded, return the current name so that does not appear to be renamed
+                if ((node as Function).State == ElementState.Error && (node as Function).Definition.IsProxy)
+                {
+                    return node.Name;
+                }
+                // If the custom node is loaded, return original name as usual
+                var customNodeFunction = node as Function;
+                return customNodeFunction?.Definition.DisplayName;
+            }
+
+            var function = node as DSFunctionBase;
+            if (function != null)
+                return function.Controller.Definition.DisplayName;
+
+            var nodeType = node.GetType();
+            var elNameAttrib = nodeType.GetCustomAttributes<NodeNameAttribute>(false).FirstOrDefault();
+            if (elNameAttrib != null)
+                return elNameAttrib.Name;
+
+            return nodeType.FullName;
+        }
+
+        internal void ResetGroupProperties()
+        {
+            GroupGUID = Guid.Empty;
+            GroupName = string.Empty;
+            GroupExecutionOrderNumber = null;
+            GroupExecutionTime = TimeSpan.Zero;
+        }
+
+        internal void ApplyGroupProperties(ProfiledNodeViewModel profiledGroup)
+        {
+            GroupGUID = profiledGroup.GroupGUID;
+            GroupName = profiledGroup.GroupName;
+            GroupExecutionOrderNumber = profiledGroup.GroupExecutionOrderNumber;
+            BackgroundBrush = profiledGroup.BackgroundBrush;
+        }
 
         /// <summary>
         /// Create a Profiled Node View Model from a NodeModel

--- a/TuneUp/TuneUpViewExtension.cs
+++ b/TuneUp/TuneUpViewExtension.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Windows.Controls;
 using Dynamo.Wpf.Extensions;
+using Dynamo.Wpf.Properties;
 
 namespace TuneUp
 {
@@ -62,11 +63,7 @@ namespace TuneUp
 
             // Add this view extension's menu item to the Extensions tab or View tab accordingly.
             var dynamoMenuItems = p.dynamoMenu.Items.OfType<MenuItem>();
-            // TODO: Investigate why TuneUpMenuItem is not added to the specified MenuItem
-            // When _Extensions is specified, TuneUpMenuItem goes to the View menu in Dynamo 3.0-
-            // and does not appear in Dynamo 3.1+.
-            // We need to specify _View for TuneUpMenuItem to be added to the Extensions menu
-            var extensionsMenuItem = dynamoMenuItems.Where(item => item.Header.ToString() == "_View");
+            var extensionsMenuItem = dynamoMenuItems.Where(item => item.Header.ToString() == Resources.DynamoViewExtensionsMenu);
 
             if (extensionsMenuItem.Count() > 0)
             {

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -444,7 +444,10 @@
                               x:Name="LatestRunTable"
                               Style="{StaticResource DataGridStyleTuneUpCombined}"
                               AlternatingRowBackground="#434343"
-                              Sorting="LatestRunTable_Sorting">
+                              Sorting="LatestRunTable_Sorting"
+                              SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                              PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                              MouseLeave="NodeAnalysisTable_MouseLeave">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
                             <DataGridTextColumn Width="40"
@@ -493,7 +496,10 @@
                               Style="{StaticResource DataGridStyleTuneUpCombined}"
                               AlternatingRowBackground="#434343"
                               HeadersVisibility="None"
-                              Sorting="LatestRunTable_Sorting">
+                              Sorting="LatestRunTable_Sorting"
+                              SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                              PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                              MouseLeave="NodeAnalysisTable_MouseLeave">
                         <DataGrid.Columns>
                             <!--Execution Order-->
                             <DataGridTextColumn Width="40"
@@ -540,7 +546,10 @@
                               AlternatingRowBackground="#434343"
                               HeadersVisibility="None"
                               CanUserSortColumns="False"
-                              Sorting="NotExecutedTable_Sorting">                       
+                              Sorting="NotExecutedTable_Sorting"
+                              SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                              PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                              MouseLeave="NodeAnalysisTable_MouseLeave">                       
                         <DataGrid.Columns>
                             <!--Execution Order-->
                             <DataGridTextColumn Width="40"/>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -454,10 +454,16 @@
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
                             <DataGridTextColumn Width="40"
-                                                Binding="{Binding Converter={StaticResource ExecutionOrderNumberConverter}}"
                                                 Header="#">
                                 <DataGridTextColumn.ElementStyle>
-                                    <Style BasedOn="{StaticResource ExecutionOrderTextBlockStyle}" TargetType="TextBlock"/>
+                                <Style BasedOn="{StaticResource ExecutionOrderTextBlockStyle}" TargetType="TextBlock">
+                                    <Setter Property="Text" Value="{Binding ExecutionOrderNumber}" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding DataContext.ShowGroups, RelativeSource={RelativeSource AncestorType=DataGrid}}" Value="True">
+                                            <Setter Property="Text" Value="{Binding GroupExecutionOrderNumber}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                             <!--  Node Name  -->
@@ -508,7 +514,14 @@
                             <DataGridTextColumn Width="40"
                                                 Binding="{Binding Converter={StaticResource ExecutionOrderNumberConverter}}" >
                                 <DataGridTextColumn.ElementStyle>
-                                    <Style BasedOn="{StaticResource ExecutionOrderTextBlockStyle}" TargetType="TextBlock"/>
+                                    <Style BasedOn="{StaticResource ExecutionOrderTextBlockStyle}" TargetType="TextBlock">
+                                        <Setter Property="Text" Value="{Binding ExecutionOrderNumber}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding DataContext.ShowGroups, RelativeSource={RelativeSource AncestorType=DataGrid}}" Value="True">
+                                                <Setter Property="Text" Value="{Binding GroupExecutionOrderNumber}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                             <!--Node Name-->

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -21,12 +21,12 @@
             <local:IsGroupToMarginMultiConverter x:Key="IsGroupToMarginMultiConverter" />
             <local:IsGroupToVisibilityMultiConverter x:Key="IsGroupToVisibilityMultiConverter" />
             <local:ExecutionOrderNumberVisibilityConverter x:Key="ExecutionOrderNumberVisibilityConverter" />
-            <local:IsGroupToColorBrushConverter x:Key="IsGroupToColorBrushConverter" />
             <local:IsGroupToColorBrushMultiConverter x:Key="IsGroupToColorBrushMultiConverter" />
             <local:IsInGroupToColorBrushMultiConverter x:Key="IsInGroupToColorBrushMultiConverter" />
             <local:IsRenamedToVisibilityMultiConverter x:Key="IsRenamedToVisibilityMultiConverter" />
             <local:ExecutionOrderNumberConverter x:Key="ExecutionOrderNumberConverter" />
             <local:ContainsStringConverter x:Key="ContainsStringConverter" />
+            <local:IsGroupAndBackgroundToForegroundConverter x:Key="IsGroupAndBackgroundToForegroundConverter" />
             <!--  ERROR : DYNAMO CRASHES WHEN REFERENCED FROM DYNAMOCOREWPF  -->
             <Color x:Key="BorderColorTuneUp">#555555</Color>
             <SolidColorBrush x:Key="BorderColorBrushTuneUp" Color="{StaticResource BorderColorTuneUp}" />
@@ -211,7 +211,10 @@
                                 </MultiBinding>
                             </TextBlock.Margin>
                             <TextBlock.Foreground>
-                                <Binding Converter="{StaticResource IsGroupToColorBrushConverter}" Path="IsGroup" />
+                                <MultiBinding Converter="{StaticResource IsGroupAndBackgroundToForegroundConverter}">
+                                    <Binding Path="IsGroup" />
+                                    <Binding Path="BackgroundBrush" />
+                                </MultiBinding>
                             </TextBlock.Foreground>
                         </TextBlock>
                     </Border>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -74,8 +74,8 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
-                            <DockPanel LastChildFill="False" HorizontalAlignment="Left">
-                                <!-- Sort Arrow -->
+                            <DockPanel HorizontalAlignment="Left" LastChildFill="False">
+                                <!--  Sort Arrow  -->
                                 <Path
                                     x:Name="SortArrow"
                                     Width="7"
@@ -83,12 +83,12 @@
                                     Margin="5,0,0,0"
                                     VerticalAlignment="Center"
                                     Data="M0,0 L0,2 L4,6 L8,2 L8,0 L4,4 z"
+                                    DockPanel.Dock="Right"
                                     Fill="{StaticResource UnSelectedLayoutForeground}"
                                     RenderTransformOrigin="0.5,0.5"
                                     Stretch="Fill"
-                                    Visibility="Collapsed"
-                                    DockPanel.Dock="Right" />
-                                <!-- Header Content -->
+                                    Visibility="Collapsed" />
+                                <!--  Header Content  -->
                                 <ContentPresenter
                                     x:Name="HeaderContent"
                                     HorizontalAlignment="Left"
@@ -154,8 +154,11 @@
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
-            <!-- TextBlock style for "ExecutionOrder" Column-->
-            <Style x:Key="ExecutionOrderTextBlockStyle" BasedOn="{StaticResource DataGridTextBlockStyle}" TargetType="TextBlock">
+            <!--  TextBlock style for "ExecutionOrder" Column  -->
+            <Style
+                x:Key="ExecutionOrderTextBlockStyle"
+                BasedOn="{StaticResource DataGridTextBlockStyle}"
+                TargetType="TextBlock">
                 <Setter Property="Visibility">
                     <Setter.Value>
                         <MultiBinding Converter="{StaticResource ExecutionOrderNumberVisibilityConverter}">
@@ -166,7 +169,7 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-            <!-- DataTemplate for "Name" Column -->
+            <!--  DataTemplate for "Name" Column  -->
             <DataTemplate x:Key="NodeNameTemplate">
                 <Grid>
                     <Grid.ColumnDefinitions>
@@ -174,7 +177,7 @@
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" MinWidth="8" />
                     </Grid.ColumnDefinitions>
-                    <!-- Group indicator -->
+                    <!--  Group indicator  -->
                     <Border Grid.Column="0" Margin="5,0,0,0">
                         <Border.Background>
                             <MultiBinding Converter="{StaticResource IsInGroupToColorBrushMultiConverter}" Mode="OneWay">
@@ -185,7 +188,7 @@
                             </MultiBinding>
                         </Border.Background>
                     </Border>
-                    <!-- Node name -->
+                    <!--  Node name  -->
                     <Border Grid.Column="1">
                         <Border.Background>
                             <MultiBinding Converter="{StaticResource IsGroupToColorBrushMultiConverter}">
@@ -218,7 +221,7 @@
                             </TextBlock.Foreground>
                         </TextBlock>
                     </Border>
-                    <!-- Renamed node indicator -->
+                    <!--  Renamed node indicator  -->
                     <Border Grid.Column="2">
                         <Border.Background>
                             <MultiBinding Converter="{StaticResource IsGroupToColorBrushMultiConverter}">
@@ -227,14 +230,15 @@
                             </MultiBinding>
                         </Border.Background>
                     </Border>
-                    <Ellipse Name="nodeRenamedBlueDot"
-                             Grid.Column="2"
-                             Width="6"
-                             Height="6"
-                             Margin="5,0,8,0"
-                             HorizontalAlignment="Right"
-                             VerticalAlignment="Center"
-                             Fill="{StaticResource Blue300Brush}">
+                    <Ellipse
+                        Name="nodeRenamedBlueDot"
+                        Grid.Column="2"
+                        Width="6"
+                        Height="6"
+                        Margin="5,0,8,0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Fill="{StaticResource Blue300Brush}">
                         <Ellipse.ToolTip>
                             <ToolTip Style="{StaticResource GenericToolTipLight}">
                                 <TextBlock>
@@ -253,46 +257,49 @@
                     </Ellipse>
                 </Grid>
             </DataTemplate>
-            <!-- TextBlock style for "ExecutionTime" Columns -->
-            <Style x:Key="ExecutionTimeTextBlockStyle" BasedOn="{StaticResource DataGridTextBlockStyle}" TargetType="TextBlock">
+            <!--  TextBlock style for "ExecutionTime" Columns  -->
+            <Style
+                x:Key="ExecutionTimeTextBlockStyle"
+                BasedOn="{StaticResource DataGridTextBlockStyle}"
+                TargetType="TextBlock">
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding IsGroup}" Value="True">
                         <Setter Property="Visibility" Value="Collapsed" />
                     </DataTrigger>
                 </Style.Triggers>
             </Style>
-            <!-- TextBlock style-->
+            <!--  TextBlock style  -->
             <Style TargetType="TextBlock">
                 <Setter Property="Foreground" Value="{StaticResource DarkThemeBodyMediumBrush}" />
                 <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
             </Style>
-            <!-- StackPanel style for total time headers -->
+            <!--  StackPanel style for total time headers  -->
             <Style x:Key="TotalTimeHeaderStackPanelStyle" TargetType="StackPanel">
                 <Setter Property="Orientation" Value="Horizontal" />
                 <Setter Property="HorizontalAlignment" Value="Left" />
                 <Setter Property="Height" Value="20" />
             </Style>
-            <!-- StackPanel style for collection footer -->
+            <!--  StackPanel style for collection footer  -->
             <Style x:Key="CollectionFooterStackPanelStyle" TargetType="StackPanel">
                 <Setter Property="Orientation" Value="Horizontal" />
                 <Setter Property="HorizontalAlignment" Value="Right" />
                 <Setter Property="Height" Value="25" />
             </Style>
-            <!-- TextBlock style for collection footer -->
+            <!--  TextBlock style for collection footer  -->
             <Style x:Key="CollectionFooterTextBlockStyle" TargetType="TextBlock">
-                <Setter Property="Height" Value="20"/>
-                <Setter Property="FontSize" Value="12"/>
-                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementBold}"/>
+                <Setter Property="Height" Value="20" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementBold}" />
             </Style>
-            <!-- TextBlock style for collection header -->
+            <!--  TextBlock style for collection header  -->
             <Style x:Key="CollectionHeaderTextBlockStyle" TargetType="TextBlock">
-                <Setter Property="Height" Value="20"/>
-                <Setter Property="FontSize" Value="12"/>
-                <Setter Property="Margin" Value="5,0,0,0"/>
-                <Setter Property="FontWeight" Value="Normal"/>
+                <Setter Property="Height" Value="20" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="Margin" Value="5,0,0,0" />
+                <Setter Property="FontWeight" Value="Normal" />
             </Style>
-            <!--  Button style *** -->
-            <!-- PackageManager\Controls\ControlColorsAndBrushes -->
+            <!--  Button style ***  -->
+            <!--  PackageManager\Controls\ControlColorsAndBrushes  -->
             <Style x:Key="ButtonStyleTuneUp" TargetType="{x:Type Button}">
                 <Setter Property="Foreground" Value="{StaticResource DarkThemeBodyMediumBrush}" />
                 <Setter Property="Background" Value="Transparent" />
@@ -332,82 +339,90 @@
                     </Trigger>
                 </Style.Triggers>
             </Style>
-            <!-- Context Menu style for Export button * -->
-            <Style x:Key="ContextMenuStyleTuneUp" TargetType="{x:Type ContextMenu}" BasedOn="{StaticResource ContextMenuStyle}">
+            <!--  Context Menu style for Export button *  -->
+            <Style
+                x:Key="ContextMenuStyleTuneUp"
+                BasedOn="{StaticResource ContextMenuStyle}"
+                TargetType="{x:Type ContextMenu}">
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ContextMenu}">
-                            <Border x:Name="Border"
-                                    Background="{TemplateBinding Background}"
-                                    BorderThickness="0px">
-                                <StackPanel IsItemsHost="True"
-                                            Margin="0"
-                                            ClipToBounds="True"
-                                            Orientation="Vertical" />
+                            <Border
+                                x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderThickness="0px">
+                                <StackPanel
+                                    Margin="0"
+                                    ClipToBounds="True"
+                                    IsItemsHost="True"
+                                    Orientation="Vertical" />
                             </Border>
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
             </Style>
         </Grid.Resources>
-        
+
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" MinWidth="150"/>
+            <ColumnDefinition Width="*" MinWidth="150" />
             <ColumnDefinition Width="150" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!--  Execution Times  -->
-        <StackPanel Grid.Row="0"
-                    Grid.Column="0"
-                    HorizontalAlignment="Left"
-                    Orientation="Vertical">
-            <TextBlock Text="Graph execution time (ms)"
-                       Margin="5,0,0,0"
-                       Height="20">
-            </TextBlock>
+        <StackPanel
+            Grid.Row="0"
+            Grid.Column="0"
+            HorizontalAlignment="Left"
+            Orientation="Vertical">
+            <TextBlock
+                Height="20"
+                Margin="5,0,0,0"
+                Text="Graph execution time (ms)" />
             <StackPanel Style="{StaticResource TotalTimeHeaderStackPanelStyle}">
-                <TextBlock Width="70"
-                           Margin="5,0,0,0"
-                           Text="Latest"/>
-                <TextBlock Text="{Binding Path=LatestGraphExecutionTime, Mode=OneWay}"/>
+                <TextBlock
+                    Width="70"
+                    Margin="5,0,0,0"
+                    Text="Latest" />
+                <TextBlock Text="{Binding Path=LatestGraphExecutionTime, Mode=OneWay}" />
             </StackPanel>
             <StackPanel Style="{StaticResource TotalTimeHeaderStackPanelStyle}">
-                <TextBlock Width="70"
-                           Margin="5,0,0,0"
-                           Text="Previous"/>
-                <TextBlock Text="{Binding Path=PreviousGraphExecutionTime, Mode=OneWay}"/>
+                <TextBlock
+                    Width="70"
+                    Margin="5,0,0,0"
+                    Text="Previous" />
+                <TextBlock Text="{Binding Path=PreviousGraphExecutionTime, Mode=OneWay}" />
             </StackPanel>
             <StackPanel Style="{StaticResource TotalTimeHeaderStackPanelStyle}">
-                <TextBlock Width="70"
-                           Margin="5,0,0,0"
-                           Text="Total"
-                           FontFamily="{StaticResource ArtifaktElementBold}"/>
-                <TextBlock Text="{Binding Path=TotalGraphExecutionTime, Mode=OneWay}"
-                           FontFamily="{StaticResource ArtifaktElementBold}"/>
+                <TextBlock
+                    Width="70"
+                    Margin="5,0,0,0"
+                    FontFamily="{StaticResource ArtifaktElementBold}"
+                    Text="Total" />
+                <TextBlock FontFamily="{StaticResource ArtifaktElementBold}" Text="{Binding Path=TotalGraphExecutionTime, Mode=OneWay}" />
             </StackPanel>
         </StackPanel>
         <!--  Show Groups Button  -->
-        <StackPanel Grid.Row="0"
-                    Grid.Column="1"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Top"
-                    Orientation="Horizontal">
-            <ToggleButton Width="30"
-                          Height="15"
-                          Margin="2,0,0,0"
-                          VerticalAlignment="Center"
-                          IsChecked="{Binding ShowGroups, Mode=TwoWay}"
-                          IsEnabled="True"
-                          Style="{StaticResource EllipseToggleButton1}" />
-            <TextBlock Margin="5,0,7,0"
-                       Text="Show groups">
-            </TextBlock>
+        <StackPanel
+            Grid.Row="0"
+            Grid.Column="1"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Top"
+            Orientation="Horizontal">
+            <ToggleButton
+                Width="30"
+                Height="15"
+                Margin="2,0,0,0"
+                VerticalAlignment="Center"
+                IsChecked="{Binding ShowGroups, Mode=TwoWay}"
+                IsEnabled="True"
+                Style="{StaticResource EllipseToggleButton1}" />
+            <TextBlock Margin="5,0,7,0" Text="Show groups" />
             <!--<Rectangle Width="16"
                        Height="16"
                        Margin="10,0,7,0"
@@ -418,101 +433,45 @@
             </Rectangle>-->
         </StackPanel>
         <!--  Run All Button  -->
-        <Button Grid.Row="1"
-                Grid.Column="2"
-                Content="Run All"
-                Width="60"
-                Height="24"
-                Margin="0,0,7,20"
-                Padding="5,2,5,2"
-                HorizontalAlignment="Right"
-                BorderBrush="{StaticResource BorderMediumColorBrush}"
-                Click="RecomputeGraph_Click"
-                IsEnabled="{Binding Path=IsRecomputeEnabled}"
-                Style="{StaticResource ButtonStyleTuneUp}"
-                Cursor="Hand">
-        </Button>
+        <Button
+            Grid.Row="1"
+            Grid.Column="2"
+            Width="60"
+            Height="24"
+            Margin="0,0,7,20"
+            Padding="5,2,5,2"
+            HorizontalAlignment="Right"
+            BorderBrush="{StaticResource BorderMediumColorBrush}"
+            Click="RecomputeGraph_Click"
+            Content="Run All"
+            Cursor="Hand"
+            IsEnabled="{Binding Path=IsRecomputeEnabled}"
+            Style="{StaticResource ButtonStyleTuneUp}" />
         <!--  Data Grids  -->
-        <Grid Name="Nodes"
-              Grid.Row="2"
-              Grid.Column="0"
-              Grid.ColumnSpan="2">
+        <Grid
+            Name="Nodes"
+            Grid.Row="2"
+            Grid.Column="0"
+            Grid.ColumnSpan="2">
             <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <StackPanel >
-                    <!-- Latest Run -->
-                    <TextBlock Text="Latest run"
-                               Style="{StaticResource CollectionHeaderTextBlockStyle}"
-                               Visibility="{Binding LatestRunTableVisibility}"/>
-                    <DataGrid ItemsSource="{Binding Path=ProfiledNodesCollectionLatestRun.View}"
-                              x:Name="LatestRunTable"
-                              Style="{StaticResource DataGridStyleTuneUpCombined}"
-                              AlternatingRowBackground="#434343"
-                              Sorting="LatestRunTable_Sorting"
-                              SelectionChanged="NodeAnalysisTable_SelectionChanged"
-                              PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
-                              MouseLeave="NodeAnalysisTable_MouseLeave">
+                <StackPanel>
+                    <!--  Latest Run  -->
+                    <TextBlock
+                        Style="{StaticResource CollectionHeaderTextBlockStyle}"
+                        Text="Latest run"
+                        Visibility="{Binding LatestRunTableVisibility}" />
+                    <DataGrid
+                        x:Name="LatestRunTable"
+                        AlternatingRowBackground="#434343"
+                        ItemsSource="{Binding Path=ProfiledNodesCollectionLatestRun.View}"
+                        MouseLeave="NodeAnalysisTable_MouseLeave"
+                        PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                        SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                        Sorting="LatestRunTable_Sorting"
+                        Style="{StaticResource DataGridStyleTuneUpCombined}">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
-                            <DataGridTextColumn Width="40"
-                                                Header="#">
-                                <DataGridTextColumn.ElementStyle>
-                                <Style BasedOn="{StaticResource ExecutionOrderTextBlockStyle}" TargetType="TextBlock">
-                                    <Setter Property="Text" Value="{Binding ExecutionOrderNumber}" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding DataContext.ShowGroups, RelativeSource={RelativeSource AncestorType=DataGrid}}" Value="True">
-                                            <Setter Property="Text" Value="{Binding GroupExecutionOrderNumber}" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                                </DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                            <!--  Node Name  -->
-                            <DataGridTemplateColumn Width="*"
-                                                    Header="Name"
-                                                    SortMemberPath="Name">
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <StaticResource ResourceKey="NodeNameTemplate" />
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                            <!--  Execution Time  -->
-                            <DataGridTextColumn Width="120"
-                                                Binding="{Binding ExecutionMilliseconds}"
-                                                Header="Execution time (ms)"
-                                                IsReadOnly="True">
-                                <DataGridTextColumn.ElementStyle>
-                                    <Style BasedOn="{StaticResource ExecutionTimeTextBlockStyle}" TargetType="TextBlock"/>
-                                </DataGridTextColumn.ElementStyle>
-                            </DataGridTextColumn>
-                        </DataGrid.Columns>
-                    </DataGrid>
-                    <StackPanel Style="{StaticResource CollectionFooterStackPanelStyle}"
-                                Visibility="{Binding LatestRunTableVisibility}">
-                        <TextBlock Text="Total"
-                                   Style="{StaticResource CollectionFooterTextBlockStyle}"/>
-                        <TextBlock Text="{Binding Path=LatestGraphExecutionTime, Mode=OneWay}"
-                                   Style="{StaticResource CollectionFooterTextBlockStyle}"
-                                   Width="120"
-                                   HorizontalAlignment="Left"
-                                   Margin="10,0,0,0"
-                                   Padding="7,0,0,0"/>
-                    </StackPanel>
-                    <!-- Previous Run -->
-                    <TextBlock Text="Previous run"
-                               Style="{StaticResource CollectionHeaderTextBlockStyle}"
-                               Visibility="{Binding PreviousRunTableVisibility}"/>
-                    <DataGrid ItemsSource="{Binding Path=ProfiledNodesCollectionPreviousRun.View}"
-                              x:Name="PreviousRunTable"
-                              Style="{StaticResource DataGridStyleTuneUpCombined}"
-                              AlternatingRowBackground="#434343"
-                              HeadersVisibility="None"
-                              Sorting="LatestRunTable_Sorting"
-                              SelectionChanged="NodeAnalysisTable_SelectionChanged"
-                              PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
-                              MouseLeave="NodeAnalysisTable_MouseLeave">
-                        <DataGrid.Columns>
-                            <!--Execution Order-->
-                            <DataGridTextColumn Width="40"
-                                                Binding="{Binding Converter={StaticResource ExecutionOrderNumberConverter}}" >
+                            <DataGridTextColumn Width="40" Header="#">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style BasedOn="{StaticResource ExecutionOrderTextBlockStyle}" TargetType="TextBlock">
                                         <Setter Property="Text" Value="{Binding ExecutionOrderNumber}" />
@@ -524,59 +483,121 @@
                                     </Style>
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
-                            <!--Node Name-->
+                            <!--  Node Name  -->
+                            <DataGridTemplateColumn
+                                Width="*"
+                                Header="Name"
+                                SortMemberPath="Name">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <StaticResource ResourceKey="NodeNameTemplate" />
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <!--  Execution Time  -->
+                            <DataGridTextColumn
+                                Width="120"
+                                Binding="{Binding ExecutionMilliseconds}"
+                                Header="Execution time (ms)"
+                                IsReadOnly="True">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style BasedOn="{StaticResource ExecutionTimeTextBlockStyle}" TargetType="TextBlock" />
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <StackPanel Style="{StaticResource CollectionFooterStackPanelStyle}" Visibility="{Binding LatestRunTableVisibility}">
+                        <TextBlock Style="{StaticResource CollectionFooterTextBlockStyle}" Text="Total" />
+                        <TextBlock
+                            Width="120"
+                            Margin="10,0,0,0"
+                            Padding="7,0,0,0"
+                            HorizontalAlignment="Left"
+                            Style="{StaticResource CollectionFooterTextBlockStyle}"
+                            Text="{Binding Path=LatestGraphExecutionTime, Mode=OneWay}" />
+                    </StackPanel>
+                    <!--  Previous Run  -->
+                    <TextBlock
+                        Style="{StaticResource CollectionHeaderTextBlockStyle}"
+                        Text="Previous run"
+                        Visibility="{Binding PreviousRunTableVisibility}" />
+                    <DataGrid
+                        x:Name="PreviousRunTable"
+                        AlternatingRowBackground="#434343"
+                        HeadersVisibility="None"
+                        ItemsSource="{Binding Path=ProfiledNodesCollectionPreviousRun.View}"
+                        MouseLeave="NodeAnalysisTable_MouseLeave"
+                        PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                        SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                        Sorting="LatestRunTable_Sorting"
+                        Style="{StaticResource DataGridStyleTuneUpCombined}">
+                        <DataGrid.Columns>
+                            <!--  Execution Order  -->
+                            <DataGridTextColumn Width="40" Binding="{Binding Converter={StaticResource ExecutionOrderNumberConverter}}">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style BasedOn="{StaticResource ExecutionOrderTextBlockStyle}" TargetType="TextBlock">
+                                        <Setter Property="Text" Value="{Binding ExecutionOrderNumber}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding DataContext.ShowGroups, RelativeSource={RelativeSource AncestorType=DataGrid}}" Value="True">
+                                                <Setter Property="Text" Value="{Binding GroupExecutionOrderNumber}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+                            <!--  Node Name  -->
                             <DataGridTemplateColumn Width="*" SortMemberPath="Name">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <StaticResource ResourceKey="NodeNameTemplate" />
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <!--Execution Time-->
-                            <DataGridTextColumn Width="120"
-                                                Binding="{Binding ExecutionMilliseconds}"
-                                                IsReadOnly="True">
+                            <!--  Execution Time  -->
+                            <DataGridTextColumn
+                                Width="120"
+                                Binding="{Binding ExecutionMilliseconds}"
+                                IsReadOnly="True">
                                 <DataGridTextColumn.ElementStyle>
-                                    <Style BasedOn="{StaticResource ExecutionTimeTextBlockStyle}" TargetType="TextBlock"/>
+                                    <Style BasedOn="{StaticResource ExecutionTimeTextBlockStyle}" TargetType="TextBlock" />
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
                         </DataGrid.Columns>
                     </DataGrid>
-                    <StackPanel Style="{StaticResource CollectionFooterStackPanelStyle}"
-                                Visibility="{Binding PreviousRunTableVisibility}">
-                        <TextBlock Text="Total"
-                                   Style="{StaticResource CollectionFooterTextBlockStyle}"/>
-                        <TextBlock Text="{Binding Path=PreviousGraphExecutionTime, Mode=OneWay}"
-                                   Style="{StaticResource CollectionFooterTextBlockStyle}"
-                                   Width="120"
-                                   HorizontalAlignment="Left"
-                                   Margin="10,0,0,0"
-                                   Padding="7,0,0,0"/>
+                    <StackPanel Style="{StaticResource CollectionFooterStackPanelStyle}" Visibility="{Binding PreviousRunTableVisibility}">
+                        <TextBlock Style="{StaticResource CollectionFooterTextBlockStyle}" Text="Total" />
+                        <TextBlock
+                            Width="120"
+                            Margin="10,0,0,0"
+                            Padding="7,0,0,0"
+                            HorizontalAlignment="Left"
+                            Style="{StaticResource CollectionFooterTextBlockStyle}"
+                            Text="{Binding Path=PreviousGraphExecutionTime, Mode=OneWay}" />
                     </StackPanel>
-                    <!-- Not Executed -->
-                    <TextBlock Text="Not executed"
-                               Style="{StaticResource CollectionHeaderTextBlockStyle}"
-                               Visibility="{Binding NotExecutedTableVisibility}"/>
-                    <DataGrid ItemsSource="{Binding Path=ProfiledNodesCollectionNotExecuted.View}"
-                              x:Name="NotExecutedTable"
-                              Style="{StaticResource DataGridStyleTuneUpCombined}"
-                              AlternationCount="2"
-                              AlternatingRowBackground="#434343"
-                              HeadersVisibility="None"
-                              CanUserSortColumns="False"
-                              Sorting="NotExecutedTable_Sorting"
-                              SelectionChanged="NodeAnalysisTable_SelectionChanged"
-                              PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
-                              MouseLeave="NodeAnalysisTable_MouseLeave">                       
+                    <!--  Not Executed  -->
+                    <TextBlock
+                        Style="{StaticResource CollectionHeaderTextBlockStyle}"
+                        Text="Not executed"
+                        Visibility="{Binding NotExecutedTableVisibility}" />
+                    <DataGrid
+                        x:Name="NotExecutedTable"
+                        AlternatingRowBackground="#434343"
+                        AlternationCount="2"
+                        CanUserSortColumns="False"
+                        HeadersVisibility="None"
+                        ItemsSource="{Binding Path=ProfiledNodesCollectionNotExecuted.View}"
+                        MouseLeave="NodeAnalysisTable_MouseLeave"
+                        PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
+                        SelectionChanged="NodeAnalysisTable_SelectionChanged"
+                        Sorting="NotExecutedTable_Sorting"
+                        Style="{StaticResource DataGridStyleTuneUpCombined}">
                         <DataGrid.Columns>
-                            <!--Execution Order-->
-                            <DataGridTextColumn Width="40"/>
-                            <!--Node Name-->
+                            <!--  Execution Order  -->
+                            <DataGridTextColumn Width="40" />
+                            <!--  Node Name  -->
                             <DataGridTemplateColumn Width="*">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <StaticResource ResourceKey="NodeNameTemplate" />
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <!--Execution Time-->
-                            <DataGridTextColumn Width="120"/>
+                            <!--  Execution Time  -->
+                            <DataGridTextColumn Width="120" />
                         </DataGrid.Columns>
                     </DataGrid>
                 </StackPanel>
@@ -585,31 +606,35 @@
         <!--  Export Button  -->
         <DockPanel Grid.Row="3" Grid.Column="1">
             <Grid DockPanel.Dock="Top">
-                <Button x:Name="ExportButton"
-                        Content="Export"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Top"
-                        Margin="0,10,10,10"
-                        BorderThickness="0"
-                        Style="{StaticResource ButtonStyleTuneUp}"
-                        Click="ExportButton_OnClick"
-                        Cursor="Hand">
+                <Button
+                    x:Name="ExportButton"
+                    Margin="0,10,10,10"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    BorderThickness="0"
+                    Click="ExportButton_OnClick"
+                    Content="Export"
+                    Cursor="Hand"
+                    Style="{StaticResource ButtonStyleTuneUp}">
                     <Button.ContextMenu>
-                        <ContextMenu Name="MainContextMenu"
-                                     Style="{StaticResource ContextMenuStyleTuneUp}"
-                                     Background="{StaticResource MidGrayBrush}"
-                                     Width="170"
-                                     Height="Auto">
-                            <MenuItem Name="CSVItem"
-                                      Header="Export as CSV"
-                                      Padding="10"
-                                      FontSize="12"
-                                      Click="ExportToCsv_Click"/>
-                            <MenuItem Name="JSONItem"
-                                      Header="Export as JSON"
-                                      Padding="10"
-                                      FontSize="12"
-                                      Click="ExportToJson_Click"/>
+                        <ContextMenu
+                            Name="MainContextMenu"
+                            Width="170"
+                            Height="Auto"
+                            Background="{StaticResource MidGrayBrush}"
+                            Style="{StaticResource ContextMenuStyleTuneUp}">
+                            <MenuItem
+                                Name="CSVItem"
+                                Padding="10"
+                                Click="ExportToCsv_Click"
+                                FontSize="12"
+                                Header="Export as CSV" />
+                            <MenuItem
+                                Name="JSONItem"
+                                Padding="10"
+                                Click="ExportToJson_Click"
+                                FontSize="12"
+                                Header="Export as JSON" />
                         </ContextMenu>
                     </Button.ContextMenu>
                 </Button>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -27,7 +27,6 @@
             <local:IsRenamedToVisibilityMultiConverter x:Key="IsRenamedToVisibilityMultiConverter" />
             <local:ExecutionOrderNumberConverter x:Key="ExecutionOrderNumberConverter" />
             <local:ContainsStringConverter x:Key="ContainsStringConverter" />
-            
             <!--  ERROR : DYNAMO CRASHES WHEN REFERENCED FROM DYNAMOCOREWPF  -->
             <Color x:Key="BorderColorTuneUp">#555555</Color>
             <SolidColorBrush x:Key="BorderColorBrushTuneUp" Color="{StaticResource BorderColorTuneUp}" />
@@ -71,37 +70,33 @@
                 <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementRegular}" />
                 <Setter Property="FontSize" Value="10" />
                 <Setter Property="BorderThickness" Value="0" />
-                <Setter Property="Margin" Value="5,0,7,0" />
+                <Setter Property="Margin" Value="5,0,5,0" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <ContentPresenter
-                                    x:Name="HeaderContent"
-                                    Grid.Column="1"
-                                    Margin="11,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center" />
+                            <DockPanel LastChildFill="False" HorizontalAlignment="Left">
+                                <!-- Sort Arrow -->
                                 <Path
                                     x:Name="SortArrow"
-                                    Grid.Column="0"
                                     Width="7"
                                     Height="6"
-                                    Margin="0,0,4,0"
+                                    Margin="5,0,0,0"
                                     VerticalAlignment="Center"
                                     Data="M0,0 L0,2 L4,6 L8,2 L8,0 L4,4 z"
                                     Fill="{StaticResource UnSelectedLayoutForeground}"
                                     RenderTransformOrigin="0.5,0.5"
                                     Stretch="Fill"
-                                    Visibility="Collapsed" />
-                            </Grid>
+                                    Visibility="Collapsed"
+                                    DockPanel.Dock="Right" />
+                                <!-- Header Content -->
+                                <ContentPresenter
+                                    x:Name="HeaderContent"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    DockPanel.Dock="Left" />
+                            </DockPanel>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="SortDirection" Value="Ascending">
-                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0" />
                                     <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
                                     <Setter TargetName="SortArrow" Property="RenderTransform">
                                         <Setter.Value>
@@ -110,7 +105,6 @@
                                     </Setter>
                                 </Trigger>
                                 <Trigger Property="SortDirection" Value="Descending">
-                                    <Setter TargetName="HeaderContent" Property="Margin" Value="0" />
                                     <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
                                     <Setter TargetName="SortArrow" Property="RenderTransform">
                                         <Setter.Value>
@@ -149,7 +143,7 @@
             <!--  TextBlock style for DataGrid columns  -->
             <Style x:Key="DataGridTextBlockStyle" TargetType="TextBlock">
                 <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="Margin" Value="10,0,10,0" />
+                <Setter Property="Margin" Value="6,0,5,0" />
                 <Setter Property="Foreground" Value="{StaticResource DarkThemeBodyMediumBrush}" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsMouseOver}" Value="True">
@@ -176,12 +170,12 @@
             <DataTemplate x:Key="NodeNameTemplate">
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="7" />
+                        <ColumnDefinition Width="8" />
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" MinWidth="8" />
                     </Grid.ColumnDefinitions>
                     <!-- Group indicator -->
-                    <Border Grid.Column="0" Margin="4,0,0,0">
+                    <Border Grid.Column="0" Margin="5,0,0,0">
                         <Border.Background>
                             <MultiBinding Converter="{StaticResource IsInGroupToColorBrushMultiConverter}" Mode="OneWay">
                                 <Binding Path="IsGroup" />
@@ -242,7 +236,7 @@
                             <ToolTip Style="{StaticResource GenericToolTipLight}">
                                 <TextBlock>
                                     <TextBlock.Text>
-                                        <Binding Path="OriginalName" StringFormat="Node original name:&#x0a;{0}" />
+                                        <Binding Path="OriginalName" StringFormat="Original node name:&#x0a;{0}" />
                                     </TextBlock.Text>
                                 </TextBlock>
                             </ToolTip>
@@ -284,16 +278,15 @@
             <!-- TextBlock style for collection footer -->
             <Style x:Key="CollectionFooterTextBlockStyle" TargetType="TextBlock">
                 <Setter Property="Height" Value="20"/>
-                <Setter Property="Width" Value="120"/>
-                <Setter Property="Margin" Value="10,0,0,0"/>
                 <Setter Property="FontSize" Value="12"/>
-                <Setter Property="Padding" Value="10,0,0,0"/>
+                <Setter Property="FontFamily" Value="{StaticResource ArtifaktElementBold}"/>
             </Style>
             <!-- TextBlock style for collection header -->
             <Style x:Key="CollectionHeaderTextBlockStyle" TargetType="TextBlock">
                 <Setter Property="Height" Value="20"/>
                 <Setter Property="FontSize" Value="12"/>
                 <Setter Property="Margin" Value="5,0,0,0"/>
+                <Setter Property="FontWeight" Value="Normal"/>
             </Style>
             <!--  Button style *** -->
             <!-- PackageManager\Controls\ControlColorsAndBrushes -->
@@ -391,9 +384,9 @@
                 <TextBlock Width="70"
                            Margin="5,0,0,0"
                            Text="Total"
-                           FontWeight="Bold"/>
+                           FontFamily="{StaticResource ArtifaktElementBold}"/>
                 <TextBlock Text="{Binding Path=TotalGraphExecutionTime, Mode=OneWay}"
-                           FontWeight="Bold"/>
+                           FontFamily="{StaticResource ArtifaktElementBold}"/>
             </StackPanel>
         </StackPanel>
         <!--  Show Groups Button  -->
@@ -409,17 +402,17 @@
                           IsChecked="{Binding ShowGroups, Mode=TwoWay}"
                           IsEnabled="True"
                           Style="{StaticResource EllipseToggleButton1}" />
-            <TextBlock Margin="5,0,0,0"
+            <TextBlock Margin="5,0,7,0"
                        Text="Show groups">
             </TextBlock>
-            <Rectangle Width="16"
+            <!--<Rectangle Width="16"
                        Height="16"
                        Margin="10,0,7,0"
                        VerticalAlignment="Center">
                 <Rectangle.Fill>
                     <ImageBrush ImageSource="/DynamoCoreWpf;component/UI/Images/help-16px.png" />
                 </Rectangle.Fill>
-            </Rectangle>
+            </Rectangle>-->
         </StackPanel>
         <!--  Run All Button  -->
         <Button Grid.Row="1"
@@ -444,7 +437,7 @@
             <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <StackPanel >
                     <!-- Latest Run -->
-                    <TextBlock Text="Latest Run"
+                    <TextBlock Text="Latest run"
                                Style="{StaticResource CollectionHeaderTextBlockStyle}"
                                Visibility="{Binding LatestRunTableVisibility}"/>
                     <DataGrid ItemsSource="{Binding Path=ProfiledNodesCollectionLatestRun.View}"
@@ -472,7 +465,7 @@
                             <!--  Execution Time  -->
                             <DataGridTextColumn Width="120"
                                                 Binding="{Binding ExecutionMilliseconds}"
-                                                Header="Execution Time (ms)"
+                                                Header="Execution time (ms)"
                                                 IsReadOnly="True">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style BasedOn="{StaticResource ExecutionTimeTextBlockStyle}" TargetType="TextBlock"/>
@@ -483,12 +476,16 @@
                     <StackPanel Style="{StaticResource CollectionFooterStackPanelStyle}"
                                 Visibility="{Binding LatestRunTableVisibility}">
                         <TextBlock Text="Total"
-                                   Style="{StaticResource CollectionHeaderTextBlockStyle}"/>
-                        <TextBlock Text="{Binding Path=LatestGraphExecutionTime, Mode=OneWay}"
                                    Style="{StaticResource CollectionFooterTextBlockStyle}"/>
+                        <TextBlock Text="{Binding Path=LatestGraphExecutionTime, Mode=OneWay}"
+                                   Style="{StaticResource CollectionFooterTextBlockStyle}"
+                                   Width="120"
+                                   HorizontalAlignment="Left"
+                                   Margin="10,0,0,0"
+                                   Padding="7,0,0,0"/>
                     </StackPanel>
                     <!-- Previous Run -->
-                    <TextBlock Text="Previous Run"
+                    <TextBlock Text="Previous run"
                                Style="{StaticResource CollectionHeaderTextBlockStyle}"
                                Visibility="{Binding PreviousRunTableVisibility}"/>
                     <DataGrid ItemsSource="{Binding Path=ProfiledNodesCollectionPreviousRun.View}"
@@ -524,12 +521,16 @@
                     <StackPanel Style="{StaticResource CollectionFooterStackPanelStyle}"
                                 Visibility="{Binding PreviousRunTableVisibility}">
                         <TextBlock Text="Total"
-                                   Style="{StaticResource CollectionHeaderTextBlockStyle}"/>
+                                   Style="{StaticResource CollectionFooterTextBlockStyle}"/>
                         <TextBlock Text="{Binding Path=PreviousGraphExecutionTime, Mode=OneWay}"
-                                   Style="{StaticResource CollectionFooterTextBlockStyle}" />
+                                   Style="{StaticResource CollectionFooterTextBlockStyle}"
+                                   Width="120"
+                                   HorizontalAlignment="Left"
+                                   Margin="10,0,0,0"
+                                   Padding="7,0,0,0"/>
                     </StackPanel>
                     <!-- Not Executed -->
-                    <TextBlock Text="Not Executed"
+                    <TextBlock Text="Not executed"
                                Style="{StaticResource CollectionHeaderTextBlockStyle}"
                                Visibility="{Binding NotExecutedTableVisibility}"/>
                     <DataGrid ItemsSource="{Binding Path=ProfiledNodesCollectionNotExecuted.View}"

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Media;
 using Dynamo.Extensions;
 using Dynamo.Graph.Nodes;
 using Dynamo.Models;
+using Dynamo.UI;
 using Dynamo.Utilities;
 using Dynamo.Wpf.Extensions;
 
@@ -222,21 +223,56 @@ namespace TuneUp
         }
     }
 
-    public class IsGroupToColorBrushConverter : IValueConverter
+    public class IsGroupAndBackgroundToForegroundConverter : IMultiValueConverter
     {
-        private static readonly SolidColorBrush GroupBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#333333"));
-        private static readonly SolidColorBrush DarkThemeBodyMediumBrush = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#F5F5F5"));
+        private static readonly SolidColorBrush LightBrush = new SolidColorBrush((Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["WhiteColor"]);
+        private static readonly SolidColorBrush DarkBrush = new SolidColorBrush((Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["DarkerGrey"]);
 
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            return value is bool isGroup && isGroup ? GroupBrush : DarkThemeBodyMediumBrush;
+            if (values.Length != 2 ||
+                !(values[0] is bool isGroup) ||
+                !(values[1] is SolidColorBrush backgroundBrush))
+            {
+                return LightBrush;
+            }
+
+            if (!isGroup)
+            {
+                return LightBrush;
+            }
+            var backgroundColor = backgroundBrush.Color;
+            var contrastRatio = GetContrastRatio((Color)SharedDictionaryManager.DynamoColorsAndBrushesDictionary["DarkerGrey"], backgroundColor);
+
+            return contrastRatio < 4.5 ? LightBrush : DarkBrush;
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
             throw new NotImplementedException();
         }
-    }    
+
+        private double GetContrastRatio(Color foreground, Color background)
+        {
+            double L1 = GetRelativeLuminance(foreground);
+            double L2 = GetRelativeLuminance(background);
+
+            return L1 > L2 ? (L1 + 0.05) / (L2 + 0.05) : (L2 + 0.05) / (L1 + 0.05);
+        }
+
+        private double GetRelativeLuminance(Color color)
+        {
+            var R = color.R / 255.0;
+            var G = color.G / 255.0;
+            var B = color.B / 255.0;
+
+            R = R < 0.03928 ? R / 12.92 : Math.Pow((R + 0.055) / 1.055, 2.4);
+            G = G < 0.03928 ? G / 12.92 : Math.Pow((G + 0.055) / 1.055, 2.4);
+            B = B < 0.03928 ? B / 12.92 : Math.Pow((B + 0.055) / 1.055, 2.4);
+
+            return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+        }
+    }
 
     public class IsGroupToVisibilityMultiConverter : IMultiValueConverter
     {

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -165,7 +165,7 @@ namespace TuneUp
             {
                 if ( isGroup || !groupGuid.Equals(DefaultGuid)) return new System.Windows.Thickness(5,0,0,0);
             }
-            return new System.Windows.Thickness(-4,0,0,0);
+            return new System.Windows.Thickness(-3,0,0,0);
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -345,7 +345,8 @@ namespace TuneUp
                     {
                         GroupGUID = groupGUID,
                         GroupName = group.AnnotationText,
-                        BackgroundBrush = groupBackgroundBrush
+                        BackgroundBrush = groupBackgroundBrush,
+                        ShowGroupIndicator = ShowGroups
                     };
                     ProfiledNodesNotExecuted.Add(profiledNode);
                     nodeDictionary[node.GUID] = profiledNode;
@@ -371,11 +372,14 @@ namespace TuneUp
             ApplyGroupNodeFilter();
             ApplyCustomSorting(ProfiledNodesCollectionNotExecuted, SortByName);
 
-            RefreshAllCollectionViews();
+            //RefreshAllCollectionViews();
+            //RaisePropertyChanged(nameof(ProfiledNodesNotExecuted));
 
             RaisePropertyChanged(nameof(ProfiledNodesCollectionNotExecuted));
-            RaisePropertyChanged(nameof(ProfiledNodesNotExecuted));
 
+            // Ensure table visibility is updated in case TuneUp was closed and reopened with the same graph.
+            RaisePropertyChanged(nameof(LatestRunTableVisibility));
+            RaisePropertyChanged(nameof(PreviousRunTableVisibility));
             RaisePropertyChanged(nameof(NotExecutedTableVisibility));
         }
 
@@ -568,6 +572,7 @@ namespace TuneUp
                                 profiledGroup.GroupExecutionTime += node.ExecutionTime; // accurate, for sorting
                                 profiledGroup.ExecutionMilliseconds += node.ExecutionMilliseconds; // rounded, for display in UI
                                 node.GroupExecutionOrderNumber = groupExecutionCounter;
+                                node.ShowGroupIndicator = ShowGroups;
                                 if (groupIsRenamed)
                                 {
                                     node.GroupName = profiledGroup.GroupName;
@@ -603,6 +608,15 @@ namespace TuneUp
                     profiledNode.GroupExecutionTime = profiledNode.ExecutionTime;
                 }
             }
+
+            // Additional sorting to prevent group nodes from appearing at the bottom of the DataGrid
+            // when consecutive graphs are opened while TuneUp is enabled.
+            ProfiledNodesCollectionLatestRun.Dispatcher.Invoke(() =>
+            {
+                ApplyCustomSorting(ProfiledNodesCollectionLatestRun);
+                RaisePropertyChanged(nameof(ProfiledNodesCollectionLatestRun));
+            });
+
         }
 
         internal void OnNodeExecutionBegin(NodeModel nm)

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -18,6 +18,7 @@ using Dynamo.ViewModels;
 using Dynamo.Wpf.Extensions;
 using Microsoft.Win32;
 using Newtonsoft.Json;
+using ProtoCore.AST.AssociativeAST;
 
 namespace TuneUp
 {
@@ -707,10 +708,73 @@ namespace TuneUp
                     hasChanges = true;
                 }
 
+                // Detect if a node is removed from the group
+                if (e.PropertyName == nameof(groupModel.Nodes))
+                {
+                    var existingProfiledNodesInGroup = groupDictionary[groupModel.GUID].ToList();
+                    var currentGroupNodeGuids = groupModel.Nodes
+                        .OfType<NodeModel>()
+                        .Select(node => node.GUID)
+                        .ToList();
+
+                    // REMOVE nodes that are no longer in the group
+                    var profiledNodesToRemove = existingProfiledNodesInGroup
+                        .Where(profiledNode => !profiledNode.IsGroupExecutionTime && !currentGroupNodeGuids.Contains(profiledNode.NodeModel.GUID))
+                        .ToList();
+
+                    foreach (var profiledNode in profiledNodesToRemove)
+                    {
+                        profiledNode.ResetGroupProperties();
+                        existingProfiledNodesInGroup.Remove(profiledNode);
+                        groupDictionary[groupModel.GUID].Remove(profiledNode);
+                    }
+
+                    // ADD new nodes that are in the updated group but not in the logged group
+                    var profiledNodesToAdd = nodeDictionary
+                        .Where(kvp => currentGroupNodeGuids.Contains(kvp.Key) && !existingProfiledNodesInGroup.Contains(kvp.Value))
+                        .Select(kvp => kvp.Value)
+                        .ToList();
+
+                    foreach (var profiledNode in profiledNodesToAdd)
+                    {
+                        profiledNode.ApplyGroupProperties(profiledGroup);
+                        profiledNode.ShowGroupIndicator = ShowGroups;
+                        existingProfiledNodesInGroup.Add(profiledNode);
+                        groupDictionary[groupModel.GUID].Add(profiledNode);
+                    }
+
+                    // Update group execution time
+                    var totalExecutionMilliseconds = existingProfiledNodesInGroup
+                        .Where(n => !n.IsGroupExecutionTime)
+                        .Sum(n => n.ExecutionMilliseconds);
+                    var totalExecutionTime = existingProfiledNodesInGroup
+                        .Where(n => !n.IsGroupExecutionTime)
+                        .Select(n => n.ExecutionTime)
+                        .Aggregate(TimeSpan.Zero, (sum, next) => sum + next);
+
+                    profiledGroup.ExecutionMilliseconds = totalExecutionMilliseconds;
+                    profiledGroup.GroupExecutionTime = totalExecutionTime;
+
+                    // update the grouped nodes
+                    foreach (var profiledNode in existingProfiledNodesInGroup)
+                    {
+                        profiledNode.GroupExecutionTime = totalExecutionTime;
+                        if (profiledNode.IsGroupExecutionTime)
+                        {
+                            profiledNode.ExecutionMilliseconds = totalExecutionMilliseconds;
+                        }
+                    }
+                    var c = existingProfiledNodesInGroup;
+                    var b = groupDictionary[groupModel.GUID];
+
+                    hasChanges = true;
+                }
+
                 // Refresh UI if any changes were made
                 if (hasChanges)
                 {
                     NotifyProfilingCollectionsChanged();
+                    // Refresh all collections as a group may contain nodes from multiple collections.
                     RefreshAllCollectionViews();
                 }
             }
@@ -772,12 +836,8 @@ namespace TuneUp
                         nodeDictionary[node.GUID] = profiledNode;
                         ProfiledNodesNotExecuted.Add(profiledNode);
                     }
-                    profiledNode.GroupGUID = group.GUID;
-                    profiledNode.GroupName = group.AnnotationText;
-                    profiledNode.GroupExecutionOrderNumber = profiledGroup.GroupExecutionOrderNumber;
-                    profiledNode.BackgroundBrush = profiledGroup.BackgroundBrush;
+                    profiledNode.ApplyGroupProperties(profiledGroup);
                     profiledNode.ShowGroupIndicator = ShowGroups;
-
                     groupDictionary[group.GUID].Add(profiledNode);
                 }
             }
@@ -812,10 +872,7 @@ namespace TuneUp
                     }
 
                     // Reset properties for each grouped node
-                    profiledNode.GroupGUID = Guid.Empty;
-                    profiledNode.GroupName = string.Empty;
-                    profiledNode.ExecutionOrderNumber = null;
-                    profiledNode.GroupExecutionTime = TimeSpan.Zero;
+                    profiledNode.ResetGroupProperties();
                 }
             }
 
@@ -839,7 +896,7 @@ namespace TuneUp
 
         #endregion
 
-        #region Helpers
+        #region Helpers        
 
         private ProfiledNodeViewModel CreateGroupTotalTimeNode(ProfiledNodeViewModel profiledGroup)
         {
@@ -901,6 +958,7 @@ namespace TuneUp
             ProfiledNodesCollectionPreviousRun?.View?.Refresh();
             ProfiledNodesCollectionNotExecuted?.View?.Refresh();
         }
+
         /// <summary>
         /// Notifies the system that all profiling node collections have changed,
         /// triggering any necessary updates in the user interface.


### PR DESCRIPTION
This PR aims to address point 3. of the resent feedback on TuneUp's revised control layout : "Fix Grouping is not accurate in some cases"
For reference : [Mural](https://app.mural.co/t/autodesk2145/m/autodesk2145/1726671147065/f22bbd9296463ee3376ffd3c5be0a9e68028b323?sender=u63a4c10277115ad8dc555082) 
Additionaly, it also addresses one of the comments in https://jira.autodesk.com/browse/DYN-7334 :
"Removing node from a group doesn't update it in the extension, even after clocking on Run All again or toggling Show Groups"

![3 3_Improvements_2](https://github.com/user-attachments/assets/117167ca-9f37-4d86-80b3-534868bcd964)


@QilongTang 
@reddyashish 

@Amoursol 
@dnenov