### PR TITLE
[DYN-7463] Mouse scroll doesn't work in the TuneUp list

### DIFF
--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -450,7 +450,8 @@
                               Sorting="LatestRunTable_Sorting"
                               SelectionChanged="NodeAnalysisTable_SelectionChanged"
                               PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
-                              MouseLeave="NodeAnalysisTable_MouseLeave">
+                              MouseLeave="NodeAnalysisTable_MouseLeave"
+                              PreviewMouseWheel="DataGrid_PreviewMouseWheel">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
                             <DataGridTextColumn Width="40"
@@ -502,7 +503,8 @@
                               Sorting="LatestRunTable_Sorting"
                               SelectionChanged="NodeAnalysisTable_SelectionChanged"
                               PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
-                              MouseLeave="NodeAnalysisTable_MouseLeave">
+                              MouseLeave="NodeAnalysisTable_MouseLeave"
+                              PreviewMouseWheel="DataGrid_PreviewMouseWheel">
                         <DataGrid.Columns>
                             <!--Execution Order-->
                             <DataGridTextColumn Width="40"
@@ -552,7 +554,8 @@
                               Sorting="NotExecutedTable_Sorting"
                               SelectionChanged="NodeAnalysisTable_SelectionChanged"
                               PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
-                              MouseLeave="NodeAnalysisTable_MouseLeave">                       
+                              MouseLeave="NodeAnalysisTable_MouseLeave"
+                              PreviewMouseWheel="DataGrid_PreviewMouseWheel">                       
                         <DataGrid.Columns>
                             <!--Execution Order-->
                             <DataGridTextColumn Width="40"/>

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -97,6 +97,48 @@ namespace TuneUp
             isUserInitiatedSelection = false;
         }
 
+        /// <summary>
+        /// Forwards the mouse wheel scroll event from the DataGrid to the parent ScrollViewer,
+        /// enabling scrolling when the mouse is over the DataGrid.
+        /// </summary>
+        private void DataGrid_PreviewMouseWheel(object sender, System.Windows.Input.MouseWheelEventArgs e)
+        {
+            ScrollViewer scrollViewer = FindParent<ScrollViewer>((DataGrid)sender);
+
+            if (scrollViewer != null)
+            {
+                if (e.Delta > 0)
+                {
+                    scrollViewer.LineUp();
+                }
+                else
+                {
+                    scrollViewer.LineDown();
+                }
+
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Recursively searches the visual tree to find the parent of the specified type T for a given child element.
+        /// </summary>
+        private T FindParent<T>(DependencyObject child) where T : DependencyObject
+        {
+            DependencyObject parentObject = VisualTreeHelper.GetParent(child);
+            if (parentObject == null) return null;
+
+            T parent = parentObject as T;
+            if (parent != null)
+            {
+                return parent;
+            }
+            else
+            {
+                return FindParent<T>(parentObject);
+            }
+        }
+
         private void RecomputeGraph_Click(object sender, RoutedEventArgs e)
         {
             (LatestRunTable.DataContext as TuneUpWindowViewModel).ResetProfiling();


### PR DESCRIPTION
PR aims to address https://jira.autodesk.com/browse/DYN-7463

The code has been modified to capture the `MouseWheel` event from the `DataGrids` and forward it to the parent `ScrollViewer`

![DYN-7463_Fix](https://github.com/user-attachments/assets/8e3a9c16-50b3-407f-a48c-f2dd8ff80b23)

@QilongTang
@reddyashish

@Amoursol
@dnenov