### PR TITLE
[DYN-7466] Navigate-to-corresponding-node/group-by-clicking-it-in-the-TuneUp-list

### DIFF
--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Windows.Media;
 using Dynamo.Core;
-using Dynamo.Graph;
 using Dynamo.Graph.Annotations;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Nodes.CustomNodes;
@@ -115,7 +114,7 @@ namespace TuneUp
         /// </summary>
         public string Name
         {
-            get
+            get 
             {
                 // For virtual row, do not attempt to grab node or group name if it's already handled
                 if (!this.IsGroupExecutionTime)

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -333,6 +333,7 @@ namespace TuneUp
         internal Stopwatch Stopwatch { get; set; }
 
         internal NodeModel NodeModel { get; set; }
+        internal AnnotationModel GroupModel { get; set; }
 
         #endregion
 
@@ -367,7 +368,7 @@ namespace TuneUp
         /// <param name="group">the annotation model</param>
         public ProfiledNodeViewModel(AnnotationModel group)
         {
-            NodeModel = null;
+            GroupModel = group;
             Name = $"{GroupNodePrefix}{group.AnnotationText}";
             GroupName = group.AnnotationText;
             GroupGUID = group.GUID;

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -128,10 +128,7 @@ namespace TuneUp
             get
             {
                 // For virtual row, do not attempt to grab node or group name if it's already handled
-                //if (!name.Contains(ExecutionTimelString) &&
-                //    !name.StartsWith(GroupNodePrefix) &&
-                //    !name.Equals(GroupExecutionTimeString))
-                if (this.ModelBase !=null)
+                if (!this.IsGroupExecutionTime)
                 {
 
                     // Check the type of BaseModel and assign the appropriate name

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -63,41 +63,6 @@ namespace TuneUp
         public bool IsGroupExecutionTime => NodeModel == null && GroupModel == null;
 
         /// <summary>
-        /// Getting the original name before graph author renamed the node
-        /// </summary>
-        private static string GetOriginalName(NodeModel node)
-        {
-            if (node == null) return string.Empty;
-            // For dummy node, return the current name so that does not appear to be renamed
-            if (node is DummyNode)
-            {
-                return node.Name;
-            }
-            if (node.IsCustomFunction)
-            {
-                // If the custom node is not loaded, return the current name so that does not appear to be renamed
-                if ((node as Function).State == ElementState.Error && (node as Function).Definition.IsProxy)
-                {
-                    return node.Name;
-                }
-                // If the custom node is loaded, return original name as usual
-                var customNodeFunction = node as Function;
-                return customNodeFunction?.Definition.DisplayName;
-            }
-
-            var function = node as DSFunctionBase;
-            if (function != null)
-                return function.Controller.Definition.DisplayName;
-
-            var nodeType = node.GetType();
-            var elNameAttrib = nodeType.GetCustomAttributes<NodeNameAttribute>(false).FirstOrDefault();
-            if (elNameAttrib != null)
-                return elNameAttrib.Name;
-
-            return nodeType.FullName;
-        }
-
-        /// <summary>
         /// Prefix string of execution time.
         /// </summary>
         internal const string ExecutionTimelString = "Execution Time";

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
@@ -8,7 +7,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Media;
 using Dynamo.Extensions;
-using Dynamo.Graph.Nodes;
+using Dynamo.Graph;
 using Dynamo.Models;
 using Dynamo.UI;
 using Dynamo.Utilities;
@@ -56,26 +55,20 @@ namespace TuneUp
         {
             if (!isUserInitiatedSelection) return;
 
-            // Get NodeModel(s) that correspond to selected row(s)
-            var selectedNodes = new List<NodeModel>();
-            foreach (var item in e.AddedItems)
-            {
-                // Check NodeModel valid before actual selection
-                var nodeModel = (item as ProfiledNodeViewModel).NodeModel;
-                if (nodeModel != null)
-                {
-                    selectedNodes.Add(nodeModel);
-                }
-            }
+            var selectedItem = e.AddedItems.OfType<ProfiledNodeViewModel>().FirstOrDefault();
+            if (selectedItem == null) return;
 
-            if (selectedNodes.Count() > 0)
+            // Extract the GUID and type (NodeModel or GroupModel)
+            var modelBase = selectedItem.NodeModel ?? (ModelBase)selectedItem.GroupModel;
+
+            if (modelBase != null)
             {
-                // Select
-                var command = new DynamoModel.SelectModelCommand(selectedNodes.Select(nm => nm.GUID), ModifierKeys.None);
+                // Execute selection command
+                var command = new DynamoModel.SelectModelCommand(new[] { modelBase.GUID }, ModifierKeys.None);
                 commandExecutive.ExecuteCommand(command, uniqueId, "TuneUp");
 
-                // Focus on selected
-                viewModelCommandExecutive.FindByIdCommand(selectedNodes.First().GUID.ToString());
+                // Focus on selected element
+                viewModelCommandExecutive.FindByIdCommand(modelBase.GUID.ToString());
             }
         }
 

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -52,7 +52,7 @@ namespace TuneUp
         }
 
         private void NodeAnalysisTable_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
+        {   
             if (!isUserInitiatedSelection) return;
 
             var selectedItem = e.AddedItems.OfType<ProfiledNodeViewModel>().FirstOrDefault();

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -58,8 +58,7 @@ namespace TuneUp
             var selectedItem = e.AddedItems.OfType<ProfiledNodeViewModel>().FirstOrDefault();
             if (selectedItem == null) return;
 
-            // Extract the GUID and type (NodeModel or GroupModel)
-            var modelBase = selectedItem.NodeModel ?? (ModelBase)selectedItem.GroupModel;
+            var modelBase = selectedItem.ModelBase;
 
             if (modelBase != null)
             {

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -56,17 +56,34 @@ namespace TuneUp
             if (!isUserInitiatedSelection) return;
 
             var selectedItem = e.AddedItems.OfType<ProfiledNodeViewModel>().FirstOrDefault();
+
             if (selectedItem == null) return;
 
-            var modelBase = selectedItem.ModelBase;
+            // Extract the GUID and type (NodeModel or GroupModel)
+            var modelBase = selectedItem.NodeModel ?? (ModelBase)selectedItem.GroupModel;
 
             if (modelBase != null)
             {
-                // Execute selection command
+                // Clear the selection in other DataGrids based on the sender
+                if (sender == LatestRunTable)
+                {
+                    NotExecutedTable.SelectedItem = null;
+                    PreviousRunTable.SelectedItem = null;
+                }
+                else if (sender == NotExecutedTable)
+                {
+                    LatestRunTable.SelectedItem = null;
+                    PreviousRunTable.SelectedItem = null;
+                }
+                else if (sender == PreviousRunTable)
+                {
+                    LatestRunTable.SelectedItem = null;
+                    NotExecutedTable.SelectedItem = null;
+                }
+
                 var command = new DynamoModel.SelectModelCommand(new[] { modelBase.GUID }, ModifierKeys.None);
                 commandExecutive.ExecuteCommand(command, uniqueId, "TuneUp");
 
-                // Focus on selected element
                 viewModelCommandExecutive.FindByIdCommand(modelBase.GUID.ToString());
             }
         }

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -835,7 +835,7 @@ namespace TuneUp
                 GroupGUID = profiledGroup.GroupGUID,
                 GroupName = profiledGroup.GroupName,
                 BackgroundBrush = profiledGroup.BackgroundBrush,
-                IsGroupExecutionTime = true,
+                //IsGroupExecutionTime = true,
                 ShowGroupIndicator = true
             };
 

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -835,7 +835,6 @@ namespace TuneUp
                 GroupGUID = profiledGroup.GroupGUID,
                 GroupName = profiledGroup.GroupName,
                 BackgroundBrush = profiledGroup.BackgroundBrush,
-                //IsGroupExecutionTime = true,
                 ShowGroupIndicator = true
             };
 

--- a/TuneUpTests/TuneUpTests.cs
+++ b/TuneUpTests/TuneUpTests.cs
@@ -94,7 +94,7 @@ namespace TuneUpTests
                 Assert.AreEqual(ProfiledNodeState.ExecutedOnCurrentRun, node.State);
             }
 
-            // Mark downstream node as modified so that it gets re-executed on the next graph run
+            // Mark downstream node as modified so that it gets reexecuted on the next graph run
             var modifiedNodeID = new Guid("1e49be233be846688122ac48d70ce961");
             var homespace = Model.CurrentWorkspace as HomeWorkspaceModel;
             homespace.Nodes.Where(n => n.GUID == modifiedNodeID).First().MarkNodeAsModified(true);

--- a/TuneUpTests/TuneUpTests.cs
+++ b/TuneUpTests/TuneUpTests.cs
@@ -53,7 +53,7 @@ namespace TuneUpTests
             var profiledNodes = tuneUpVE.ViewModel.ProfiledNodesNotExecuted;
             foreach (var node in nodes)
             {
-                Assert.Contains(node.GUID, profiledNodes.Select(n => n.ModelBase.GUID).ToList());
+                Assert.Contains(node.GUID, profiledNodes.Select(n => n.NodeModel.GUID).ToList());
             }
 
             RunCurrentModel();
@@ -104,7 +104,7 @@ namespace TuneUpTests
             DispatcherUtil.DoEvents();
             foreach (var node in profiledNodes)
             {
-                if (node.ModelBase.GUID == modifiedNodeID)
+                if (node.NodeModel.GUID == modifiedNodeID)
                 {
                     Assert.AreEqual(ProfiledNodeState.ExecutedOnCurrentRun, node.State);
                 }
@@ -159,7 +159,7 @@ namespace TuneUpTests
             DispatcherUtil.DoEvents();
             foreach (var node in profiledNodes)
             {
-                var expected = executionOrderDict[node.ModelBase.GUID];
+                var expected = executionOrderDict[node.NodeModel.GUID];
                 Assert.AreEqual(expected, node.ExecutionOrderNumber);
             }
         }

--- a/TuneUpTests/TuneUpTests.cs
+++ b/TuneUpTests/TuneUpTests.cs
@@ -53,7 +53,7 @@ namespace TuneUpTests
             var profiledNodes = tuneUpVE.ViewModel.ProfiledNodesNotExecuted;
             foreach (var node in nodes)
             {
-                Assert.Contains(node.GUID, profiledNodes.Select(n => n.NodeModel.GUID).ToList());
+                Assert.Contains(node.GUID, profiledNodes.Select(n => n.ModelBase.GUID).ToList());
             }
 
             RunCurrentModel();
@@ -94,7 +94,7 @@ namespace TuneUpTests
                 Assert.AreEqual(ProfiledNodeState.ExecutedOnCurrentRun, node.State);
             }
 
-            // Mark downstream node as modified so that it gets reexecuted on the next graph run
+            // Mark downstream node as modified so that it gets re-executed on the next graph run
             var modifiedNodeID = new Guid("1e49be233be846688122ac48d70ce961");
             var homespace = Model.CurrentWorkspace as HomeWorkspaceModel;
             homespace.Nodes.Where(n => n.GUID == modifiedNodeID).First().MarkNodeAsModified(true);
@@ -104,7 +104,7 @@ namespace TuneUpTests
             DispatcherUtil.DoEvents();
             foreach (var node in profiledNodes)
             {
-                if (node.NodeModel.GUID == modifiedNodeID)
+                if (node.ModelBase.GUID == modifiedNodeID)
                 {
                     Assert.AreEqual(ProfiledNodeState.ExecutedOnCurrentRun, node.State);
                 }
@@ -159,7 +159,7 @@ namespace TuneUpTests
             DispatcherUtil.DoEvents();
             foreach (var node in profiledNodes)
             {
-                var expected = executionOrderDict[node.NodeModel.GUID];
+                var expected = executionOrderDict[node.ModelBase.GUID];
                 Assert.AreEqual(expected, node.ExecutionOrderNumber);
             }
         }


### PR DESCRIPTION
PR aims to address https://jira.autodesk.com/browse/DYN-7466 .

- Group nodes are now centered when selected from the node list.
- Selecting a node from one list will deselect all selected nodes from other lists.
- ProfiledNodeViewModel now includes a GroupModel property, and IsGroup and IsGroupExecutionTime are now getter-only properties. Due to these changes, some optimizations can be made in TuneUpWindowViewModel, but they will be addressed in a future PR.

Goes along with https://github.com/DynamoDS/Dynamo/pull/15504

![DYN-7466_Fix](https://github.com/user-attachments/assets/f76e0696-ae3f-4fc7-8c93-7fab75476467)


@QilongTang 
@reddyashish 

@Amoursol 
@dnenov
