### PR TITLE
3.4 Improvement - show executed 0ms nodes as 1ms

### DIFF
--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -173,6 +173,20 @@ namespace TuneUp
         private int executionMilliseconds;
 
         /// <summary>
+        /// The total execution time of this group in milliseconds
+        /// </summary>
+        public int GroupExecutionMilliseconds
+        {
+            get => groupExecutionMilliseconds;
+            set
+            {
+                groupExecutionMilliseconds = value;
+                RaisePropertyChanged(nameof(GroupExecutionMilliseconds));
+            }
+        }
+        private int groupExecutionMilliseconds;
+
+        /// <summary>
         /// Indicates whether this node was executed on the most recent graph run
         /// </summary>
         public bool WasExecutedOnLastRun
@@ -244,7 +258,6 @@ namespace TuneUp
             }
         }
         private bool showGroupIndicator;
-
 
         /// <summary>
         /// The background brush for this node
@@ -333,7 +346,7 @@ namespace TuneUp
             GroupGUID = Guid.Empty;
             GroupName = string.Empty;
             GroupExecutionOrderNumber = null;
-            GroupExecutionTime = TimeSpan.Zero;
+            GroupExecutionMilliseconds = 0;
         }
 
         internal void ApplyGroupProperties(ProfiledNodeViewModel profiledGroup)
@@ -359,12 +372,10 @@ namespace TuneUp
         /// An alternative constructor which we can customize data for display in TuneUp datagrid
         /// </summary>
         /// <param name="name">row display name</param>
-        /// <param name="exTimeSum">execution time in ms</param>
         /// <param name="state">state which determine grouping</param>
-        public ProfiledNodeViewModel(string name, TimeSpan exTimeSum, ProfiledNodeState state)
+        public ProfiledNodeViewModel(string name, ProfiledNodeState state)
         {
             this.Name = name;
-            this.ExecutionTime = exTimeSum;
             State = state;
         }
 

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -71,7 +71,6 @@ namespace TuneUp
         private const string DefaultGroupName = "Title <Double click here to edit group title>";
         private const string DefaultDisplayGroupName = "Title";
 
-        private string name = String.Empty;
         /// <summary>
         /// The name of this profiled node. This value can be either an actual
         /// node name or can be virtually any row you want to append to 
@@ -98,7 +97,8 @@ namespace TuneUp
             }
             internal set { name = value; }
         }
-        
+        private string name = String.Empty;
+
         /// <summary>
         /// The order number of this node in the most recent graph run.
         /// Returns null if the node was not executed during the most recent graph run.
@@ -130,35 +130,6 @@ namespace TuneUp
         private int? groupExecutionOrderNumber;
 
         /// <summary>
-        /// The most recent execution time of this node
-        /// </summary>
-        public TimeSpan ExecutionTime
-        {
-            get => executionTime;
-            set
-            {
-                executionTime = value;
-                RaisePropertyChanged(nameof(ExecutionTime));
-                RaisePropertyChanged(nameof(ExecutionMilliseconds));
-            }
-        }
-        private TimeSpan executionTime;
-
-        /// <summary>
-        /// The total execution time of all node in the group.
-        /// </summary>
-        public TimeSpan GroupExecutionTime
-        {
-            get => groupExecutionTime;
-            set
-            {
-                groupExecutionTime = value;
-                RaisePropertyChanged(nameof(GroupExecutionTime));
-            }
-        }
-        private TimeSpan groupExecutionTime;
-
-        /// <summary>
         /// The most recent execution time of this node in milliseconds
         /// </summary>
         public int ExecutionMilliseconds
@@ -171,6 +142,20 @@ namespace TuneUp
             }
         }
         private int executionMilliseconds;
+
+        /// <summary>
+        /// The total execution time of the group in milliseconds
+        /// </summary>
+        public int GroupExecutionMilliseconds
+        {
+            get => groupExecutionMilliseconds;
+            set
+            {
+                groupExecutionMilliseconds = value;
+                RaisePropertyChanged(nameof(GroupExecutionMilliseconds));
+            }
+        }
+        private int groupExecutionMilliseconds;
 
         /// <summary>
         /// Indicates whether this node was executed on the most recent graph run
@@ -244,7 +229,6 @@ namespace TuneUp
             }
         }
         private bool showGroupIndicator;
-
 
         /// <summary>
         /// The background brush for this node
@@ -333,7 +317,7 @@ namespace TuneUp
             GroupGUID = Guid.Empty;
             GroupName = string.Empty;
             GroupExecutionOrderNumber = null;
-            GroupExecutionTime = TimeSpan.Zero;
+            GroupExecutionMilliseconds = 0;
         }
 
         internal void ApplyGroupProperties(ProfiledNodeViewModel profiledGroup)
@@ -361,10 +345,9 @@ namespace TuneUp
         /// <param name="name">row display name</param>
         /// <param name="exTimeSum">execution time in ms</param>
         /// <param name="state">state which determine grouping</param>
-        public ProfiledNodeViewModel(string name, TimeSpan exTimeSum, ProfiledNodeState state)
+        public ProfiledNodeViewModel(string name, ProfiledNodeState state)
         {
             this.Name = name;
-            this.ExecutionTime = exTimeSum;
             State = state;
         }
 

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -71,6 +71,7 @@ namespace TuneUp
         private const string DefaultGroupName = "Title <Double click here to edit group title>";
         private const string DefaultDisplayGroupName = "Title";
 
+        private string name = String.Empty;
         /// <summary>
         /// The name of this profiled node. This value can be either an actual
         /// node name or can be virtually any row you want to append to 
@@ -97,8 +98,7 @@ namespace TuneUp
             }
             internal set { name = value; }
         }
-        private string name = String.Empty;
-
+        
         /// <summary>
         /// The order number of this node in the most recent graph run.
         /// Returns null if the node was not executed during the most recent graph run.
@@ -130,6 +130,35 @@ namespace TuneUp
         private int? groupExecutionOrderNumber;
 
         /// <summary>
+        /// The most recent execution time of this node
+        /// </summary>
+        public TimeSpan ExecutionTime
+        {
+            get => executionTime;
+            set
+            {
+                executionTime = value;
+                RaisePropertyChanged(nameof(ExecutionTime));
+                RaisePropertyChanged(nameof(ExecutionMilliseconds));
+            }
+        }
+        private TimeSpan executionTime;
+
+        /// <summary>
+        /// The total execution time of all node in the group.
+        /// </summary>
+        public TimeSpan GroupExecutionTime
+        {
+            get => groupExecutionTime;
+            set
+            {
+                groupExecutionTime = value;
+                RaisePropertyChanged(nameof(GroupExecutionTime));
+            }
+        }
+        private TimeSpan groupExecutionTime;
+
+        /// <summary>
         /// The most recent execution time of this node in milliseconds
         /// </summary>
         public int ExecutionMilliseconds
@@ -142,20 +171,6 @@ namespace TuneUp
             }
         }
         private int executionMilliseconds;
-
-        /// <summary>
-        /// The total execution time of the group in milliseconds
-        /// </summary>
-        public int GroupExecutionMilliseconds
-        {
-            get => groupExecutionMilliseconds;
-            set
-            {
-                groupExecutionMilliseconds = value;
-                RaisePropertyChanged(nameof(GroupExecutionMilliseconds));
-            }
-        }
-        private int groupExecutionMilliseconds;
 
         /// <summary>
         /// Indicates whether this node was executed on the most recent graph run
@@ -229,6 +244,7 @@ namespace TuneUp
             }
         }
         private bool showGroupIndicator;
+
 
         /// <summary>
         /// The background brush for this node
@@ -317,7 +333,7 @@ namespace TuneUp
             GroupGUID = Guid.Empty;
             GroupName = string.Empty;
             GroupExecutionOrderNumber = null;
-            GroupExecutionMilliseconds = 0;
+            GroupExecutionTime = TimeSpan.Zero;
         }
 
         internal void ApplyGroupProperties(ProfiledNodeViewModel profiledGroup)
@@ -345,9 +361,10 @@ namespace TuneUp
         /// <param name="name">row display name</param>
         /// <param name="exTimeSum">execution time in ms</param>
         /// <param name="state">state which determine grouping</param>
-        public ProfiledNodeViewModel(string name, ProfiledNodeState state)
+        public ProfiledNodeViewModel(string name, TimeSpan exTimeSum, ProfiledNodeState state)
         {
             this.Name = name;
+            this.ExecutionTime = exTimeSum;
             State = state;
         }
 

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -540,10 +540,9 @@ namespace TuneUp
                         ProfiledNodeViewModel groupTotalTimeNode = null;
                         bool groupIsRenamed = false;
 
-                        // Reset group state
+                        // Reset group state and execution time
                         profiledGroup.State = profiledNode.State;
-                        profiledGroup.GroupExecutionTime = TimeSpan.Zero; // Reset execution time
-                        profiledGroup.ExecutionMilliseconds = 0; // Reset UI execution time
+                        profiledGroup.GroupExecutionMilliseconds = 0;
                         MoveNodeToCollection(profiledGroup, ProfiledNodesLatestRun); // Ensure the profiledGroup is in latest run
 
                         // Check if the group has been renamed
@@ -565,8 +564,7 @@ namespace TuneUp
                             else if (processedNodes.Add(node))
                             {
                                 // Update group state, execution order, and execution time
-                                profiledGroup.GroupExecutionTime += node.ExecutionTime; // accurate, for sorting
-                                profiledGroup.ExecutionMilliseconds += node.ExecutionMilliseconds; // rounded, for display in UI
+                                profiledGroup.GroupExecutionMilliseconds += node.ExecutionMilliseconds;
                                 node.GroupExecutionOrderNumber = groupExecutionCounter;
                                 node.ShowGroupIndicator = ShowGroups;
                                 if (groupIsRenamed)
@@ -578,7 +576,6 @@ namespace TuneUp
 
                         // Update the properties of the group node
                         profiledGroup.GroupExecutionOrderNumber = groupExecutionCounter++;
-                        profiledGroup.ExecutionTime = profiledGroup.GroupExecutionTime;
                         profiledGroup.WasExecutedOnLastRun = true;
 
 
@@ -591,7 +588,7 @@ namespace TuneUp
                         // Update the groupExecutionTime for all nodes of the group for the purposes of sorting
                         foreach (var node in nodesInGroup)
                         {
-                            node.GroupExecutionTime = profiledGroup.GroupExecutionTime;
+                            node.GroupExecutionMilliseconds = profiledGroup.GroupExecutionMilliseconds;
                         }
                     }
                 }
@@ -601,7 +598,7 @@ namespace TuneUp
                     !profiledNode.IsGroupExecutionTime)
                 {
                     profiledNode.GroupExecutionOrderNumber = groupExecutionCounter++;
-                    profiledNode.GroupExecutionTime = profiledNode.ExecutionTime;
+                    profiledNode.GroupExecutionMilliseconds = profiledNode.ExecutionMilliseconds;
                 }
             }
 
@@ -628,11 +625,11 @@ namespace TuneUp
             var executionTime = profiledNode.Stopwatch.Elapsed;
 
             if (executionTime > TimeSpan.Zero)
-            {
-                profiledNode.ExecutionTime = executionTime;
+            {                
                 // Assign execution time and manually set the execution milliseconds value
                 // so that group node execution time is based on rounded millisecond values.
-                profiledNode.ExecutionMilliseconds = (int)Math.Round(executionTime.TotalMilliseconds);
+                // Nodes should display at least 1ms execution time if they are executed.
+                profiledNode.ExecutionMilliseconds = Math.Max(1, (int)Math.Round(executionTime.TotalMilliseconds));
 
                 if (!profiledNode.WasExecutedOnLastRun)
                 {
@@ -737,22 +734,17 @@ namespace TuneUp
                         groupDictionary[groupModel.GUID].Add(profiledNode);
                     }
 
-                    // Update group execution time
+                    // Update group execution times
                     var totalExecutionMilliseconds = existingProfiledNodesInGroup
                         .Where(n => !n.IsGroupExecutionTime)
                         .Sum(n => n.ExecutionMilliseconds);
-                    var totalExecutionTime = existingProfiledNodesInGroup
-                        .Where(n => !n.IsGroupExecutionTime)
-                        .Select(n => n.ExecutionTime)
-                        .Aggregate(TimeSpan.Zero, (sum, next) => sum + next);
 
-                    profiledGroup.ExecutionMilliseconds = totalExecutionMilliseconds;
-                    profiledGroup.GroupExecutionTime = totalExecutionTime;
+                    profiledGroup.ExecutionMilliseconds = profiledGroup.GroupExecutionMilliseconds = totalExecutionMilliseconds;
 
                     // update the grouped nodes
                     foreach (var profiledNode in existingProfiledNodesInGroup)
                     {
-                        profiledNode.GroupExecutionTime = totalExecutionTime;
+                        profiledNode.GroupExecutionMilliseconds = totalExecutionMilliseconds;
                         if (profiledNode.IsGroupExecutionTime)
                         {
                             profiledNode.ExecutionMilliseconds = totalExecutionMilliseconds;
@@ -893,7 +885,7 @@ namespace TuneUp
         private ProfiledNodeViewModel CreateGroupTotalTimeNode(ProfiledNodeViewModel profiledGroup)
         {
             var groupTotalTimeNode = new ProfiledNodeViewModel(
-                ProfiledNodeViewModel.GroupExecutionTimeString, TimeSpan.Zero, ProfiledNodeState.NotExecuted)
+                ProfiledNodeViewModel.GroupExecutionTimeString, ProfiledNodeState.NotExecuted)
             {
                 GroupGUID = profiledGroup.GroupGUID,
                 GroupName = profiledGroup.GroupName,
@@ -912,8 +904,7 @@ namespace TuneUp
         private void UpdateGroupTotalTimeNodeProperties(ProfiledNodeViewModel groupTotalTimeNode, ProfiledNodeViewModel profiledGroup)
         {
             groupTotalTimeNode.State = profiledGroup.State;
-            groupTotalTimeNode.GroupExecutionTime = profiledGroup.GroupExecutionTime; // Accurate, for sorting
-            groupTotalTimeNode.ExecutionMilliseconds = profiledGroup.ExecutionMilliseconds; // Rounded, for display in UI
+            groupTotalTimeNode.GroupExecutionMilliseconds = groupTotalTimeNode.ExecutionMilliseconds = profiledGroup.GroupExecutionMilliseconds;
             groupTotalTimeNode.GroupExecutionOrderNumber = profiledGroup.GroupExecutionOrderNumber;
             groupTotalTimeNode.WasExecutedOnLastRun = true;
 
@@ -1034,15 +1025,15 @@ namespace TuneUp
                 case SortByTime:
                     if (showGroups)
                     {
-                        collection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.GroupExecutionTime), sortDirection));
+                        collection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.GroupExecutionMilliseconds), sortDirection));
                         collection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.GroupGUID), sortDirection));
                         collection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.IsGroup), ListSortDirection.Descending));
                         collection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.IsGroupExecutionTime), ListSortDirection.Ascending));
-                        collection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.ExecutionTime), sortDirection));
+                        collection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.ExecutionMilliseconds), sortDirection));
                     }
                     else
                     {
-                        collection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.ExecutionTime), sortDirection));
+                        collection.SortDescriptions.Add(new SortDescription(nameof(ProfiledNodeViewModel.ExecutionMilliseconds), sortDirection));
                     }
                     break;
                 case SortByName:


### PR DESCRIPTION
Small PR to address one of the points for improvement in [this Mural board](https://app.mural.co/t/autodesk2145/m/autodesk2145/1726671147065/f22bbd9296463ee3376ffd3c5be0a9e68028b323?sender=u63a4c10277115ad8dc555082) (don't think there is a JIRA ticket for this) :

> "3. Displaying executed nodes with 0 ms as 1 ms, as discussed in Slack."

In `OnNodeExecutionEnd`, the `TimeSpan` value is now rounded and directly assigned to `ExecutionMilliseconds` as an integer. Total group execution times are calculated as the sum of these integer values rather than exact `TimeSpan` values. Consequently, the `GroupExecutionTime` and `ExecutionTime` properties are now obsolete and removed. 

![Screenshot 2024-09-24 180251](https://github.com/user-attachments/assets/ce8c8d64-b61e-4321-9a04-e8c61fe4a5fd)
