### PR TITLE
[DYN-7463] related : force ScrollViewer to focus on loaded

### DIFF
--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -453,7 +453,8 @@
             Grid.Row="2"
             Grid.Column="0"
             Grid.ColumnSpan="2">
-            <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          Focusable="True">
                 <StackPanel >
                     <!-- Latest Run -->
                     <TextBlock Text="Latest run"
@@ -467,7 +468,8 @@
                               SelectionChanged="NodeAnalysisTable_SelectionChanged"
                               PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
                               MouseLeave="NodeAnalysisTable_MouseLeave"
-                              PreviewMouseWheel="DataGrid_PreviewMouseWheel">
+                              PreviewMouseWheel="DataGrid_PreviewMouseWheel"
+                              Loaded="ScrollViewer_Loaded">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
                             <DataGridTextColumn Width="40" Header="#">
@@ -526,7 +528,8 @@
                               SelectionChanged="NodeAnalysisTable_SelectionChanged"
                               PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
                               MouseLeave="NodeAnalysisTable_MouseLeave"
-                              PreviewMouseWheel="DataGrid_PreviewMouseWheel">
+                              PreviewMouseWheel="DataGrid_PreviewMouseWheel"
+                              Loaded="ScrollViewer_Loaded">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
                             <DataGridTextColumn Width="40" Binding="{Binding Converter={StaticResource ExecutionOrderNumberConverter}}">
@@ -583,7 +586,8 @@
                               SelectionChanged="NodeAnalysisTable_SelectionChanged"
                               PreviewMouseDown="NodeAnalysisTable_PreviewMouseDown"
                               MouseLeave="NodeAnalysisTable_MouseLeave"
-                              PreviewMouseWheel="DataGrid_PreviewMouseWheel">   
+                              PreviewMouseWheel="DataGrid_PreviewMouseWheel"
+                              Loaded="ScrollViewer_Loaded">   
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
                             <DataGridTextColumn Width="40" />

--- a/TuneUp/TuneUpWindow.xaml.cs
+++ b/TuneUp/TuneUpWindow.xaml.cs
@@ -148,6 +148,18 @@ namespace TuneUp
             }
         }
 
+        /// <summary>
+        /// Sets focus on the ScrollViewer when it is loaded to ensure immediate scroll functionality.
+        /// </summary>
+        private void ScrollViewer_Loaded(object sender, RoutedEventArgs e)
+        {
+            var scrollViewer = sender as ScrollViewer;
+            if (scrollViewer != null)
+            {
+                scrollViewer.Focus();
+            }
+        }
+
         private void RecomputeGraph_Click(object sender, RoutedEventArgs e)
         {
             (LatestRunTable.DataContext as TuneUpWindowViewModel).ResetProfiling();


### PR DESCRIPTION
PR in response to https://autodesk.slack.com/archives/CPJ5UQW0Z/p1727362943286009?thread_ts=1727192978.398829&cid=CPJ5UQW0Z

I could not replicate this behavior, but forcing the ScrollViewer to focus on loading should resolve this...
Please let me know if it works.

@QilongTang 
@reddyashish 