### PR TITLE
DYN-7337 Update Nuget Reference to remove a local dependency

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DynamoPackageVersion>3.2.1.5366</DynamoPackageVersion>
+    <DynamoPackageVersion>3.4.0-beta6405</DynamoPackageVersion>
     <MSTestVersion>1.3.2</MSTestVersion>
   </PropertyGroup>
 

--- a/TuneUpTests/TuneUpTests.csproj
+++ b/TuneUpTests/TuneUpTests.csproj
@@ -37,9 +37,6 @@
     <Reference Include="System">
       <Private>True</Private>
     </Reference>
-    <Reference Include="DynamoCoreWpfTests">
-      <HintPath>..\..\Dynamo\bin\AnyCPU\Debug\DynamoCoreWpfTests.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core">
       <Private>True</Private>
     </Reference>


### PR DESCRIPTION
A follow up PR of https://github.com/DynamoDS/Dynamo/pull/15516 to depend on the newer version of Nugets so that a local hard dependency can be removed to unblock CI.