### PR TITLE
Application.Current removed

### DIFF
--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -72,6 +72,7 @@ namespace TuneUp
         private Dictionary<Guid, ProfiledNodeViewModel> groupDictionary = new Dictionary<Guid, ProfiledNodeViewModel>();
         // Maps AnnotationModel GUIDs to a list of associated ProfiledNodeViewModel instances.
         private Dictionary<Guid, List<ProfiledNodeViewModel>> groupModelDictionary = new Dictionary<Guid, List<ProfiledNodeViewModel>>();
+        private Dictionary<ObservableCollection<ProfiledNodeViewModel>, CollectionViewSource> collectionMapping = new Dictionary<ObservableCollection<ProfiledNodeViewModel>, CollectionViewSource>();
 
         private HomeWorkspaceModel CurrentWorkspace
         {
@@ -318,6 +319,12 @@ namespace TuneUp
             ProfiledNodesPreviousRun = ProfiledNodesPreviousRun ?? new ObservableCollection<ProfiledNodeViewModel>();
             ProfiledNodesNotExecuted = ProfiledNodesNotExecuted ?? new ObservableCollection<ProfiledNodeViewModel>();
 
+            collectionMapping = new Dictionary<ObservableCollection<ProfiledNodeViewModel>, CollectionViewSource> {
+                { ProfiledNodesLatestRun, ProfiledNodesCollectionLatestRun },
+                {ProfiledNodesPreviousRun, ProfiledNodesCollectionPreviousRun },
+                {ProfiledNodesNotExecuted, ProfiledNodesCollectionNotExecuted }            
+            };
+
             nodeDictionary = new Dictionary<Guid, ProfiledNodeViewModel>();
             groupDictionary = new Dictionary<Guid, ProfiledNodeViewModel>();
             groupModelDictionary = new Dictionary<Guid, List<ProfiledNodeViewModel>>();
@@ -549,7 +556,7 @@ namespace TuneUp
                     groupDictionary[pGroup.NodeGUID] = pGroup;
                     groupModelDictionary[pNode.GroupGUID].Add(pGroup);
 
-                    System.Windows.Application.Current.Dispatcher.Invoke(() =>
+                    ProfiledNodesCollectionLatestRun.Dispatcher.Invoke(() =>
                     {
                         ProfiledNodesNotExecuted.Add(pGroup);
                     });
@@ -615,7 +622,7 @@ namespace TuneUp
                     // Create an register a new time node
                     var timeNode = CreateAndRegisterGroupTimeNode(pGroup);
 
-                    System.Windows.Application.Current.Dispatcher.Invoke(() =>
+                    GetCollectionViewSource(collection).Dispatcher.Invoke(() =>
                     {
                         collection.Add(timeNode);
                         collection.Add(pGroup);
@@ -1022,6 +1029,14 @@ namespace TuneUp
         #region Helpers
 
         /// <summary>
+        /// Returns the corresponding CollectionViewSource for the given ObservableCollection of ProfiledNodeViewModel.
+        /// </summary>
+        internal CollectionViewSource GetCollectionViewSource(ObservableCollection<ProfiledNodeViewModel> collection)
+        {
+            return collectionMapping.TryGetValue(collection, out var collectionViewSource) ? collectionViewSource : null;
+        }
+
+        /// <summary>
         /// Resets group-related properties of the node and unregisters it from the group model dictionary.
         /// </summary>
         internal void ResetGroupPropertiesAndUnregisterNode(ProfiledNodeViewModel profiledNode)
@@ -1258,7 +1273,7 @@ namespace TuneUp
         /// </summary>
         private void MoveNodeToCollection(ProfiledNodeViewModel profiledNode, ObservableCollection<ProfiledNodeViewModel> targetCollection)
         {
-            System.Windows.Application.Current.Dispatcher.Invoke(() =>
+            GetCollectionViewSource(targetCollection).Dispatcher.Invoke(() =>
             {
                 var collections = new[]
                 {
@@ -1283,7 +1298,7 @@ namespace TuneUp
         {
             var collection = GetObservableCollectionFromState(state);
 
-            System.Windows.Application.Current.Dispatcher.Invoke(() =>
+            GetCollectionViewSource(collection).Dispatcher.Invoke(() =>
             {
                 collection?.Remove(pNode);
             });


### PR DESCRIPTION
This PR fixes an issue discussed in the Slack [thread](https://autodesk.slack.com/archives/C0W60575Z/p1728936717638249) where a graph in Dynamo for Civil 3D doesn't run correctly when TuneUp is enabled. I'm not aware of a JIRA ticket for this.

The problem is that `System.Windows.Application.Current` returns `null` when trying to update collections, which stops the UI from updating properly.

I've replaced `System.Windows.Application.Current.Dispatcher` with direct access to the `CollectionViewSource` dispatcher, this should solve the problem and the UI should still update correctly.

![Civil3D Error fix](https://github.com/user-attachments/assets/9c758811-0b1d-4882-be37-8f4f0c02612c)

@reddyashish 
@QilongTang 

@dnenov
@Amoursol 
