### PR TITLE
Bug fixes - group naming & table visibility

### DIFF
--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -99,13 +99,16 @@ namespace TuneUp
                     }
                     else if (GroupModel != null)
                     {
-                        return GroupModel.AnnotationText == DefaultGroupName ?
-                            $"{GroupNodePrefix}{DefaultDisplayGroupName}" : GroupModel.AnnotationText;
+                        return GetGroupName(GroupModel.AnnotationText);
                     }
                 }
                 return name;
             }
-            internal set { name = value; }
+            internal set
+            {
+                name = value;
+                RaisePropertyChanged(nameof(Name));
+            }
         }
         
         /// <summary>
@@ -420,7 +423,7 @@ namespace TuneUp
         /// <param name="group">the annotation model</param>
         public ProfiledNodeViewModel(ProfiledNodeViewModel pNode)
         {
-            Name = pNode.GroupName == DefaultGroupName ? DefaultDisplayGroupName : pNode.GroupName;
+            Name = GetGroupName(pNode.GroupName);
             GroupName = pNode.GroupName;
             State = pNode.State;
             NodeGUID = Guid.NewGuid();
@@ -429,5 +432,13 @@ namespace TuneUp
             BackgroundBrush = pNode.BackgroundBrush;
             ShowGroupIndicator = true;
         }
+
+        public static string GetGroupName(string groupName)
+        {
+            return groupName == DefaultGroupName
+                ? $"{GroupNodePrefix}{DefaultDisplayGroupName}"
+                : $"{GroupNodePrefix}{groupName}";
+        }
+
     }
 }

--- a/TuneUp/ProfiledNodeViewModel.cs
+++ b/TuneUp/ProfiledNodeViewModel.cs
@@ -99,7 +99,7 @@ namespace TuneUp
                     }
                     else if (GroupModel != null)
                     {
-                        return GetGroupName(GroupModel.AnnotationText);
+                        return GetProfiledGroupName(GroupModel.AnnotationText);
                     }
                 }
                 return name;
@@ -423,7 +423,7 @@ namespace TuneUp
         /// <param name="group">the annotation model</param>
         public ProfiledNodeViewModel(ProfiledNodeViewModel pNode)
         {
-            Name = GetGroupName(pNode.GroupName);
+            Name = GetProfiledGroupName(pNode.GroupName);
             GroupName = pNode.GroupName;
             State = pNode.State;
             NodeGUID = Guid.NewGuid();
@@ -433,12 +433,15 @@ namespace TuneUp
             ShowGroupIndicator = true;
         }
 
-        public static string GetGroupName(string groupName)
+        /// <summary>
+        /// Returns the formatted profiled group name with the group prefix.
+        /// Uses a default display name if the group name matches the default.
+        /// </summary>
+        public static string GetProfiledGroupName(string groupName)
         {
             return groupName == DefaultGroupName
                 ? $"{GroupNodePrefix}{DefaultDisplayGroupName}"
                 : $"{GroupNodePrefix}{groupName}";
         }
-
     }
 }

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -360,9 +360,7 @@ namespace TuneUp
             ApplyGroupNodeFilter();
 
             // Ensure table visibility is updated in case TuneUp was closed and reopened with the same graph.
-            RaisePropertyChanged(nameof(LatestRunTableVisibility));
-            RaisePropertyChanged(nameof(PreviousRunTableVisibility));
-            RaisePropertyChanged(nameof(NotExecutedTableVisibility));
+            UpdateTableVisibility();
         }
 
         /// <summary>
@@ -451,10 +449,7 @@ namespace TuneUp
 
             CalculateGroupNodes();
             UpdateExecutionTime();
-
-            RaisePropertyChanged(nameof(LatestRunTableVisibility));
-            RaisePropertyChanged(nameof(PreviousRunTableVisibility));
-            RaisePropertyChanged(nameof(NotExecutedTableVisibility));
+            UpdateTableVisibility();
 
             RaisePropertyChanged(nameof(ProfiledNodesCollectionLatestRun));
             RaisePropertyChanged(nameof(ProfiledNodesCollectionPreviousRun));
@@ -699,7 +694,7 @@ namespace TuneUp
                     {
                         if (pNode.IsGroup)
                         {
-                            pNode.Name = $"{ProfiledNodeViewModel.GroupNodePrefix}{groupModel.AnnotationText}";
+                            pNode.Name = ProfiledNodeViewModel.GetGroupName(groupModel.AnnotationText);
                         }
                         pNode.GroupName = groupModel.AnnotationText;
                     }
@@ -887,6 +882,7 @@ namespace TuneUp
 
             //Recalculate the execution times
             UpdateExecutionTime();
+            UpdateTableVisibility();
         }
 
         private void CurrentWorkspaceModel_GroupAdded(AnnotationModel group)
@@ -1001,6 +997,7 @@ namespace TuneUp
             }
 
             RefreshAllCollectionViews();
+            UpdateTableVisibility();
         }
 
         private void OnCurrentWorkspaceChanged(IWorkspaceModel workspace)
@@ -1020,6 +1017,16 @@ namespace TuneUp
         #endregion
 
         #region Helpers
+
+        /// <summary>
+        /// Raises property change notifications for the visibility of the Latest Run, Previous Run, and Not Executed tables.
+        /// </summary>
+        private void UpdateTableVisibility()
+        {
+            RaisePropertyChanged(nameof(LatestRunTableVisibility));
+            RaisePropertyChanged(nameof(PreviousRunTableVisibility));
+            RaisePropertyChanged(nameof(NotExecutedTableVisibility));
+        }
 
         /// <summary>
         /// Resets group-related properties of the node and unregisters it from the group model dictionary.

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -694,7 +694,7 @@ namespace TuneUp
                     {
                         if (pNode.IsGroup)
                         {
-                            pNode.Name = ProfiledNodeViewModel.GetGroupName(groupModel.AnnotationText);
+                            pNode.Name = ProfiledNodeViewModel.GetProfiledGroupName(groupModel.AnnotationText);
                         }
                         pNode.GroupName = groupModel.AnnotationText;
                     }


### PR DESCRIPTION
Small PR to address a couple of issues I've just noticed:

1. When a group is renamed, TuneUp doesn't show the "Group: " prefix in the nodes table.
1. When all nodes or groups are deleted from a table, the table header and footer still remain visible.

_**Before:**_

<img src="https://github.com/user-attachments/assets/da2d796e-8102-4213-9579-d5f61a110101" width="600">

**_After:_**

<img src="https://github.com/user-attachments/assets/659229bd-dbb7-482c-b0d1-2c8d9e7f80ae" width="600">

@QilongTang 
@reddyashish 

@dnenov
