### PR TITLE
New paths for pipeline.yml

### DIFF
--- a/TuneUp/Properties/Resources.en-US.Designer.cs
+++ b/TuneUp/Properties/Resources.en-US.Designer.cs
@@ -22,14 +22,14 @@ namespace TuneUp.Properties {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class Resources {
+    public class Resources_en_US {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        internal Resources_en_US() {
         }
         
         /// <summary>
@@ -39,7 +39,7 @@ namespace TuneUp.Properties {
         public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("TuneUp.Properties.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("TuneUp.Properties.Resources.en-US", typeof(Resources_en_US).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -196,7 +196,7 @@ namespace TuneUp.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Group: .
+        ///   Looks up a localized string similar to Group:.
         /// </summary>
         public static string Label_GroupNodePrefix {
             get {

--- a/TuneUp/Properties/Resources.en-US.resx
+++ b/TuneUp/Properties/Resources.en-US.resx
@@ -212,7 +212,7 @@
 {0}</value>
   </data>
   <data name="ToolTip_RunAll" xml:space="preserve">
-    <value>Execure entire graph, including nodes with no change since the latest run.</value>
+    <value>Execute entire graph, including nodes with no change since the latest run.</value>
   </data>
   <data name="ToolTip_TotalExecutionTime" xml:space="preserve">
     <value>Combined execution time of latest and previous run.</value>

--- a/TuneUp/Properties/Resources.resx
+++ b/TuneUp/Properties/Resources.resx
@@ -212,7 +212,7 @@
 {0}</value>
   </data>
   <data name="ToolTip_RunAll" xml:space="preserve">
-    <value>Execure entire graph, including nodes with no change since the latest run.</value>
+    <value>Execute entire graph, including nodes with no change since the latest run.</value>
   </data>
   <data name="ToolTip_TotalExecutionTime" xml:space="preserve">
     <value>Combined execution time of latest and previous run.</value>

--- a/TuneUp/TuneUp.csproj
+++ b/TuneUp/TuneUp.csproj
@@ -52,6 +52,11 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Properties\Resources.en-US.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.en-US.resx</DependentUpon>
+    </Compile>
     <Compile Include="TuneUpViewExtension.cs" />
     <Compile Include="TuneUpWindowViewModel.cs" />
     <Compile Include="TuneUpWindow.xaml.cs">
@@ -89,17 +94,13 @@
     <None Include="manifests\TuneUp_ViewExtensionDefinition.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.en-US.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.en-US.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Update="TuneUpResources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>TuneUpResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
   <!-- Including Custom Properties, PreBuildEvent, and Import -->

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -28,7 +28,7 @@ deployment:
   -
     type: customized
     scripts:
-      - "pwsh.exe -ExecutionPolicy ByPass -Command Compress-Archive -Path (Join-Path TuneUp/bin/Release/net8.0-windows 'TuneUp.dll', 'en-US') -DestinationPath TuneUp.zip"
+      - "pwsh.exe -ExecutionPolicy ByPass -Command Compress-Archive -Path 'TuneUp/bin/Release/net8.0-windows/TuneUp.dll', 'TuneUp/bin/Release/net8.0-windows/en-US' -DestinationPath 'TuneUp.zip'"
   -
     type: artifacts
     publish_to_jenkins: true


### PR DESCRIPTION
PR aims to address:

- pipeline.yml script isn't generating TuneUp.zip with TuneUp.dll and en-US resources. I tested this locally in PowerShell using:
`Compress-Archive -Path "TuneUp\bin\Release\net8.0-windows\TuneUp.dll", "TuneUp\bin\Release\net8.0-windows\en-US" -DestinationPath "TuneUp.zip"` which created TuneUp.zip, therefore this command:
`Compress-Archive -Path 'TuneUp/bin/Release/net8.0-windows/TuneUp.dll', 'TuneUp/bin/Release/net8.0-windows/en-US' -DestinationPath 'TuneUp.zip'` should also work in the pipeline.

- The `Resources.en-US.Designer.cs` file was not generating as expected. Renaming `Resources.en-US.resx`, running the custom tool, and renaming it back resolved the issue.

- Fixed a typo in the resources file.

@QilongTang 
@reddyashish 
@dnenov