### PR TITLE
[DYN-7698] Zoom to group, doesn't work

### DIFF
--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -308,68 +308,70 @@ namespace TuneUp
         {
             if (CurrentWorkspace == null) return;
 
-            // Clear existing collections
-            ProfiledNodesLatestRun?.Clear();
-            ProfiledNodesPreviousRun?.Clear();
-            ProfiledNodesNotExecuted?.Clear();
+            uiContext.Send(_ => {
+                // Clear existing collections
+                ProfiledNodesLatestRun?.Clear();
+                ProfiledNodesPreviousRun?.Clear();
+                ProfiledNodesNotExecuted?.Clear();
 
-            // Reset execution time stats
-            LatestGraphExecutionTime = PreviousGraphExecutionTime = TotalGraphExecutionTime = defaultExecutionTime;
+                // Reset execution time stats
+                LatestGraphExecutionTime = PreviousGraphExecutionTime = TotalGraphExecutionTime = defaultExecutionTime;
 
-            // Initialize observable collections and dictionaries
-            ProfiledNodesLatestRun = ProfiledNodesLatestRun ?? new ObservableCollection<ProfiledNodeViewModel>();
-            ProfiledNodesPreviousRun = ProfiledNodesPreviousRun ?? new ObservableCollection<ProfiledNodeViewModel>();
-            ProfiledNodesNotExecuted = ProfiledNodesNotExecuted ?? new ObservableCollection<ProfiledNodeViewModel>();
+                // Initialize observable collections and dictionaries
+                ProfiledNodesLatestRun = ProfiledNodesLatestRun ?? new ObservableCollection<ProfiledNodeViewModel>();
+                ProfiledNodesPreviousRun = ProfiledNodesPreviousRun ?? new ObservableCollection<ProfiledNodeViewModel>();
+                ProfiledNodesNotExecuted = ProfiledNodesNotExecuted ?? new ObservableCollection<ProfiledNodeViewModel>();
 
-            collectionMapping = new Dictionary<ObservableCollection<ProfiledNodeViewModel>, CollectionViewSource> {
+                collectionMapping = new Dictionary<ObservableCollection<ProfiledNodeViewModel>, CollectionViewSource> {
                 { ProfiledNodesLatestRun, ProfiledNodesCollectionLatestRun },
                 {ProfiledNodesPreviousRun, ProfiledNodesCollectionPreviousRun },
-                {ProfiledNodesNotExecuted, ProfiledNodesCollectionNotExecuted }            
+                {ProfiledNodesNotExecuted, ProfiledNodesCollectionNotExecuted }
             };
 
-            nodeDictionary = new Dictionary<Guid, ProfiledNodeViewModel>();
-            groupDictionary = new Dictionary<Guid, ProfiledNodeViewModel>();
-            groupModelDictionary = new Dictionary<Guid, List<ProfiledNodeViewModel>>();
+                nodeDictionary = new Dictionary<Guid, ProfiledNodeViewModel>();
+                groupDictionary = new Dictionary<Guid, ProfiledNodeViewModel>();
+                groupModelDictionary = new Dictionary<Guid, List<ProfiledNodeViewModel>>();
 
-            // Create a profiled node for each NodeModel
-            foreach (var node in CurrentWorkspace.Nodes)
-            {
-                var profiledNode = new ProfiledNodeViewModel(node) { GroupName = node.Name };
-                ProfiledNodesNotExecuted.Add(profiledNode);
-                nodeDictionary[node.GUID] = profiledNode;
-            }
-
-            // Create a profiled node for each AnnotationModel
-            foreach (var group in CurrentWorkspace.Annotations)
-            {
-                var pGroup = new ProfiledNodeViewModel(group);
-                ProfiledNodesNotExecuted.Add(pGroup);
-                groupDictionary[pGroup.NodeGUID] = (pGroup);
-                groupModelDictionary[group.GUID] = new List<ProfiledNodeViewModel> { pGroup };
-
-                var groupedNodeGUIDs = group.Nodes.OfType<NodeModel>().Select(n => n.GUID);
-
-                foreach (var nodeGuid in groupedNodeGUIDs)
+                // Create a profiled node for each NodeModel
+                foreach (var node in CurrentWorkspace.Nodes)
                 {
-                    if (nodeDictionary.TryGetValue(nodeGuid, out var pNode))
+                    var profiledNode = new ProfiledNodeViewModel(node) { GroupName = node.Name };
+                    ProfiledNodesNotExecuted.Add(profiledNode);
+                    nodeDictionary[node.GUID] = profiledNode;
+                }
+
+                // Create a profiled node for each AnnotationModel
+                foreach (var group in CurrentWorkspace.Annotations)
+                {
+                    var pGroup = new ProfiledNodeViewModel(group);
+                    ProfiledNodesNotExecuted.Add(pGroup);
+                    groupDictionary[pGroup.NodeGUID] = (pGroup);
+                    groupModelDictionary[group.GUID] = new List<ProfiledNodeViewModel> { pGroup };
+
+                    var groupedNodeGUIDs = group.Nodes.OfType<NodeModel>().Select(n => n.GUID);
+
+                    foreach (var nodeGuid in groupedNodeGUIDs)
                     {
-                        ApplyGroupPropertiesAndRegisterNode(pNode, pGroup);
+                        if (nodeDictionary.TryGetValue(nodeGuid, out var pNode))
+                        {
+                            ApplyGroupPropertiesAndRegisterNode(pNode, pGroup);
+                        }
                     }
                 }
-            }
 
-            ProfiledNodesCollectionLatestRun = new CollectionViewSource { Source = ProfiledNodesLatestRun };
-            ProfiledNodesCollectionPreviousRun = new CollectionViewSource { Source = ProfiledNodesPreviousRun };
-            ProfiledNodesCollectionNotExecuted = new CollectionViewSource { Source = ProfiledNodesNotExecuted };
+                ProfiledNodesCollectionLatestRun = new CollectionViewSource { Source = ProfiledNodesLatestRun };
+                ProfiledNodesCollectionPreviousRun = new CollectionViewSource { Source = ProfiledNodesPreviousRun };
+                ProfiledNodesCollectionNotExecuted = new CollectionViewSource { Source = ProfiledNodesNotExecuted };
 
-            // Refresh UI if any changes were made
-            RaisePropertyChanged(nameof(ProfiledNodesCollectionNotExecuted));
-            ApplyCustomSorting(ProfiledNodesCollectionNotExecuted, SortByName);
+                // Refresh UI if any changes were made
+                RaisePropertyChanged(nameof(ProfiledNodesCollectionNotExecuted));
+                ApplyCustomSorting(ProfiledNodesCollectionNotExecuted, SortByName);
 
-            ApplyGroupNodeFilter();
+                ApplyGroupNodeFilter();
 
-            // Ensure table visibility is updated in case TuneUp was closed and reopened with the same graph.
-            UpdateTableVisibility();
+                // Ensure table visibility is updated in case TuneUp was closed and reopened with the same graph.
+                UpdateTableVisibility();
+            }, null);
         }
 
         /// <summary>

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -580,6 +580,7 @@ namespace TuneUp
         {
             int executionCounter = 1;
             var processedNodes = new HashSet<ProfiledNodeViewModel>();
+            var nodesToAdd = new HashSet<ProfiledNodeViewModel>();
 
             var sortedNodes = collection.OrderBy(n => n.ExecutionOrderNumber).ToList();
 
@@ -612,20 +613,16 @@ namespace TuneUp
                     var pGroup = new ProfiledNodeViewModel(pNode)
                     {
                         GroupExecutionOrderNumber = executionCounter++,
-                        GroupExecutionMilliseconds = groupExecTime
+                        GroupExecutionMilliseconds = groupExecTime,
+                        GroupModel = CurrentWorkspace.Annotations.First(n => n.GUID.Equals(pNode.GroupGUID))
                     };
+                    nodesToAdd.Add(pGroup);
 
                     groupDictionary[pGroup.NodeGUID] = pGroup;
                     groupModelDictionary[pNode.GroupGUID].Add(pGroup);
 
                     // Create an register a new time node
-                    var timeNode = CreateAndRegisterGroupTimeNode(pGroup);
-
-                    GetCollectionViewSource(collection).Dispatcher.Invoke(() =>
-                    {
-                        collection.Add(timeNode);
-                        collection.Add(pGroup);
-                    });
+                    nodesToAdd.Add(CreateAndRegisterGroupTimeNode(pGroup));
 
                     // Update group-related properties for all nodes in the group
                     foreach (var node in nodesInGroup)
@@ -635,6 +632,14 @@ namespace TuneUp
                     }
                 }
             }
+
+            GetCollectionViewSource(collection).Dispatcher.Invoke(() =>
+            {
+                foreach (var node in nodesToAdd)
+                {
+                    collection.Add(node);
+                }
+            });
         }
 
         internal void OnNodeExecutionBegin(NodeModel nm)


### PR DESCRIPTION
PR aims to address [DYN-7698](https://jira.autodesk.com/browse/DYN-7698) where TuneUp does not zoom-to-fit on groups after that graph has been executed.

*This branch is built from `DYN-7697-Crash-with-Periodic-Run` as I couldn't build `master`. Relevant changes are only in `CreateGroupNodesForCollection`.

![DYN-7698-ZoomToFit](https://github.com/user-attachments/assets/6d0173d4-9b2c-402d-a1ce-7872791ce279)

@QilongTang 
@reddyashish 

@dnenov