### PR TITLE
[DYN-7701] Dynamo freeze on Run All in some cases

### DIFF
--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -327,7 +327,7 @@ namespace TuneUp
 
                     collectionMapping = new Dictionary<ObservableCollection<ProfiledNodeViewModel>, CollectionViewSource>
                     {
-                        { ProfiledNodesLatestRun, ProfiledNodesCollectionLatestRun },
+                        {ProfiledNodesLatestRun, ProfiledNodesCollectionLatestRun },
                         {ProfiledNodesPreviousRun, ProfiledNodesCollectionPreviousRun },
                         {ProfiledNodesNotExecuted, ProfiledNodesCollectionNotExecuted }
                     };
@@ -370,10 +370,7 @@ namespace TuneUp
                     // Refresh UI if any changes were made
                     RaisePropertyChanged(nameof(ProfiledNodesCollectionNotExecuted));
                     ApplyCustomSorting(ProfiledNodesCollectionNotExecuted, SortByName);
-
                     ApplyGroupNodeFilter();
-
-                    // Ensure table visibility is updated in case TuneUp was closed and reopened with the same graph.
                     UpdateTableVisibility();
                 }, null);
             });            
@@ -467,17 +464,18 @@ namespace TuneUp
 
                 CalculateGroupNodes();
                 UpdateExecutionTime();
-                UpdateTableVisibility();
-
-                RaisePropertyChanged(nameof(ProfiledNodesCollectionLatestRun));
-                RaisePropertyChanged(nameof(ProfiledNodesCollectionPreviousRun));
-                RaisePropertyChanged(nameof(ProfiledNodesCollectionNotExecuted));
+                UpdateTableVisibility();                
 
                 uiContext.Post(_ =>
                 {
+                    RaisePropertyChanged(nameof(ProfiledNodesCollectionLatestRun));
+                    RaisePropertyChanged(nameof(ProfiledNodesCollectionPreviousRun));
+                    RaisePropertyChanged(nameof(ProfiledNodesCollectionNotExecuted));
+
                     ApplyCustomSorting(ProfiledNodesCollectionLatestRun);
-                    ProfiledNodesCollectionLatestRun.View?.Refresh();
                     ApplyCustomSorting(ProfiledNodesCollectionPreviousRun);
+
+                    ProfiledNodesCollectionLatestRun.View?.Refresh();
                     ProfiledNodesCollectionPreviousRun.View?.Refresh();
                     ProfiledNodesCollectionNotExecuted.View?.Refresh();
                 }, null);
@@ -534,9 +532,17 @@ namespace TuneUp
                 }
                 groupDictionary.Clear();
 
+                var a1 = ProfiledNodesLatestRun;
+                var a2 = ProfiledNodesPreviousRun;
+                var a3 = ProfiledNodesNotExecuted;
+
                 // Create group and time nodes for latest and previous runs
                 CreateGroupNodesForCollection(ProfiledNodesLatestRun);
                 CreateGroupNodesForCollection(ProfiledNodesPreviousRun);
+
+                var b1 = ProfiledNodesLatestRun;
+                var b2 = ProfiledNodesPreviousRun;
+                var b3 = ProfiledNodesNotExecuted;
 
                 // Create group nodes for not executed 
                 var processedNodesNotExecuted = new HashSet<ProfiledNodeViewModel>();
@@ -1298,12 +1304,7 @@ namespace TuneUp
             {
                 uiContext.Post(_ =>
                 {
-                    var collections = new[]
-                    {
-                    ProfiledNodesLatestRun,
-                    ProfiledNodesPreviousRun,
-                    ProfiledNodesNotExecuted
-                };
+                    var collections = new[] { ProfiledNodesLatestRun, ProfiledNodesPreviousRun, ProfiledNodesNotExecuted };
 
                     foreach (var collection in collections)
                     {

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -565,10 +565,11 @@ namespace TuneUp
                             groupDictionary[pGroup.NodeGUID] = pGroup;
                             groupModelDictionary[pNode.GroupGUID].Add(pGroup);
 
-                            ProfiledNodesCollectionLatestRun.Dispatcher.Invoke(() =>
-                            {
-                                ProfiledNodesNotExecuted.Add(pGroup);
-                            });
+                            //ProfiledNodesCollectionLatestRun.Dispatcher.Invoke(() =>
+                            //{
+                            //    ProfiledNodesNotExecuted.Add(pGroup);
+                            //});
+                            uiContext.Send(_ => ProfiledNodesNotExecuted.Add(pGroup), null);
                         }
                     }
 
@@ -627,11 +628,16 @@ namespace TuneUp
                     // Create an register a new time node
                     var timeNode = CreateAndRegisterGroupTimeNode(pGroup);
 
-                    GetCollectionViewSource(collection).Dispatcher.Invoke(() =>
+                    //GetCollectionViewSource(collection).Dispatcher.Invoke(() =>
+                    //{
+                    //    collection.Add(timeNode);
+                    //    collection.Add(pGroup);
+                    //});
+                    uiContext.Post(_ =>
                     {
                         collection.Add(timeNode);
                         collection.Add(pGroup);
-                    });
+                    }, null);
 
                     // Update group-related properties for all nodes in the group
                     foreach (var node in nodesInGroup)

--- a/TuneUp/TuneUpWindowViewModel.cs
+++ b/TuneUp/TuneUpWindowViewModel.cs
@@ -550,7 +550,6 @@ namespace TuneUp
         {
             int executionCounter = 1;
             var processedNodes = new HashSet<ProfiledNodeViewModel>();
-            var nodesToAdd = new HashSet<ProfiledNodeViewModel>();
 
             var sortedNodes = collection.OrderBy(n => n.ExecutionOrderNumber).ToList();
 
@@ -602,15 +601,7 @@ namespace TuneUp
                         node.GroupExecutionMilliseconds = pGroup.GroupExecutionMilliseconds;
                     }
                 }
-            }
-
-            GetCollectionViewSource(collection).Dispatcher.Invoke(() =>
-            {
-                foreach (var node in nodesToAdd)
-                {
-                    collection.Add(node);
-                }
-            });
+            }            
         }
 
         internal void OnNodeExecutionBegin(NodeModel nm)


### PR DESCRIPTION
PR to address [DYN-7701](https://jira.autodesk.com/browse/DYN-7701)

In some cases, running "Run All" was causing Dynamo to freeze up with no error messages. After looking into it, it seems the issue was due to long-running updates blocking the UI thread. I've used `Task.Run` and `uiContext.Post` to handle these updates in the background, which seems to keep things running smoothly.

For consistency and to streamline the code, I also replaced `collection.Dispatcher` calls with `uiContext.Post`, as `Dispatcher` was causing some problems in Civil 3D anyway. I've also separated the UI update code from the main methods to clean-up the logic.

![DYN-7701-Working_cut_lowres](https://github.com/user-attachments/assets/523a6733-aced-4ef1-9532-e26699c98aee)