### PR TITLE
[DYN-7699] Panel should show run all button when panel size is very small

### DIFF
--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -391,7 +391,7 @@
 
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" MinWidth="100"/>
-            <ColumnDefinition Width="120" MinWidth="60"/>
+            <ColumnDefinition Width="120"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -474,7 +474,7 @@
             Grid.Column="1"
             Width="60"
             Height="24"
-            Margin="0,0,7,0"
+            Margin="0,0,7,8"
             Padding="5,2,5,2"
             HorizontalAlignment="Right"
             VerticalAlignment="Bottom"

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -390,8 +390,8 @@
         </Grid.Resources>
 
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" MinWidth="150" />
-            <ColumnDefinition Width="150" />
+            <ColumnDefinition Width="*" MinWidth="100"/>
+            <ColumnDefinition Width="120" MinWidth="60"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -407,8 +407,9 @@
             HorizontalAlignment="Left"
             Orientation="Vertical">
             <TextBlock
-                Height="20"
-                Margin="5,0,0,0"
+                Margin="5,0,0,3"
+                TextWrapping="Wrap"
+                TextTrimming="CharacterEllipsis"
                 Text="{x:Static resx:Resources.Label_GraphExecutionTime}" />
             <StackPanel Style="{StaticResource TotalTimeHeaderStackPanelStyle}">
                 <TextBlock
@@ -443,7 +444,7 @@
         <StackPanel
             Grid.Row="0"
             Grid.Column="1"
-            HorizontalAlignment="Right"
+            HorizontalAlignment="Stretch"
             VerticalAlignment="Top"
             Orientation="Horizontal">
             <ToggleButton
@@ -454,7 +455,10 @@
                 IsChecked="{Binding ShowGroups, Mode=TwoWay}"
                 IsEnabled="True"
                 Style="{StaticResource EllipseToggleButton1}" />
-            <TextBlock Margin="5,0,7,0" Text="{x:Static resx:Resources.Button_ShowGroups}" />
+            <TextBlock Margin="5,0,7,0"
+                       TextWrapping="Wrap"
+                       TextTrimming="CharacterEllipsis"
+                       Text="{x:Static resx:Resources.Button_ShowGroups}" />
             <!--<Rectangle Width="16"
                        Height="16"
                        Margin="10,0,7,0"
@@ -466,13 +470,14 @@
         </StackPanel>
         <!--  Run All Button  -->
         <Button
-            Grid.Row="1"
-            Grid.Column="2"
+            Grid.Row="0"
+            Grid.Column="1"
             Width="60"
             Height="24"
-            Margin="0,0,7,20"
+            Margin="0,0,7,0"
             Padding="5,2,5,2"
             HorizontalAlignment="Right"
+            VerticalAlignment="Bottom"
             BorderBrush="{StaticResource BorderMediumColorBrush}"
             Click="RecomputeGraph_Click"
             Content="{x:Static resx:Resources.Button_RunAll}"
@@ -488,6 +493,7 @@
         <!--  Data Grids  -->
         <Grid
             Name="Nodes"
+            Margin="0,10,0,0"
             Grid.Row="2"
             Grid.Column="0"
             Grid.ColumnSpan="2">


### PR DESCRIPTION
Small PR to address [DYN-7699](https://jira.autodesk.com/browse/DYN-7699)

![TuneUpWidth_241105_2](https://github.com/user-attachments/assets/fe6c8f1e-ba09-4c64-baa8-ad24d35c39e8)

@reddyashish 
@QilongTang 

@dnenov