### PR TITLE
Bump up version to reflect binary change

### DIFF
--- a/TuneUp/Properties/AssemblyInfo.cs
+++ b/TuneUp/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("TuneUp")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Autodesk, Inc")]
 [assembly: AssemblyProduct("TuneUp")]
-[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyCopyright("Copyright © Autodesk, Inc 2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: InternalsVisibleTo("TuneUpTests")]
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0")]
-[assembly: AssemblyFileVersion("2.0.0")]
+[assembly: AssemblyVersion("2.0.1")]
+[assembly: AssemblyFileVersion("2.0.1")]

--- a/TuneUp/manifests/pkg.json
+++ b/TuneUp/manifests/pkg.json
@@ -2,8 +2,8 @@
   "license": "MIT",
   "file_hash": null,
   "name": "TuneUp",
-  "version": "2.0.0",
-  "description": "On Dynamo 2.5–2.19 (.NET 4.8), use TuneUp versions up to 1.0.7.\r\nOn Dynamo 3.0+ (.NET 8), use TuneUp version 2.0.0.\r\n\r\nTuneUp is a view extension for analyzing the performance of Dynamo graphs. TuneUp allows you to see overall graph execution time, per-node execution time, execution time of groups, and other helpful information. With TuneUp, you can rerun all nodes, including ones that are normally skipped for optimization/caching during repeated runs of a graph. This enables you to compare the actual execution times between multiple runs. Read more here: https://dynamobim.org/tuneup-extension-explore-your-node-and-graph-execution-times/. \r\n\r\nKnown issues:\r\n1. TuneUp does not work in a custom node workspace.\r\n2. TuneUp binaries are not semantically versioned and are not intended to be built on top of as an API. Do not treat these binaries like DynamoCore.",
+  "version": "2.0.1",
+  "description": "On Dynamo 2.5–2.19 (.NET 4.8), use TuneUp versions up to 1.0.7.\r\nOn Dynamo 3.0+ (.NET 8), use TuneUp version 2.0.0+.\r\n\r\nTuneUp is a view extension for analyzing the performance of Dynamo graphs. TuneUp allows you to see overall graph execution time, per-node execution time, execution time of groups, and other helpful information. With TuneUp, you can rerun all nodes, including ones that are normally skipped for optimization/caching during repeated runs of a graph. This enables you to compare the actual execution times between multiple runs. Read more here: https://dynamobim.org/tuneup-extension-explore-your-node-and-graph-execution-times/. \r\n\r\nKnown issues:\r\n1. TuneUp does not work in a custom node workspace.\r\n2. TuneUp binaries are not semantically versioned and are not intended to be built on top of as an API. Do not treat these binaries like DynamoCore.",
   "group": "",
   "keywords": [
       "profiler",


### PR DESCRIPTION
Bump up version to reflect binary change, this is required so we can potentially make TuneUp constantly updated in Dynamo master branch