### PR TITLE
Remove the release PR option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Please check out known issues before trying to setup testing.
 - Click the target test to run or run them all.
 
 ### How to publish a new version
-We currently can't use the release PR option when making releases on mirrored respories. There is a propsed follow-up improvment filed that would allow CILibrary to create a PR against the public repository instead (DYN-8724). But until that is done, our release process will be:
+We currently can't use the release PR option when making releases on mirrored repositories. There is a propsed follow-up improvment filed that would allow CILibrary to create a PR against the public repository instead (DYN-8724). But until that is done, our release process will be:
 
-- Create a release branch on the internal respository
+- Create a release branch on the internal repository
 - Build the branch to publish
-- Manually create a PR on the public repsoitory with the changes introduced by the release branch (the updated version number in the pipeline file). 
+- Manually create a PR on the public repository with the changes introduced by the release branch (the updated version number in the pipeline file). 
 - Review and merge this PR
-- Delete the release branch on the internal respository
+- Delete the release branch on the internal repository

--- a/README.md
+++ b/README.md
@@ -56,3 +56,12 @@ Please check out known issues before trying to setup testing.
 - Install NUnit3TestAdapter from VisualStudio->Extensions->Manage Extensions->Online.
 - Open Test Explorer from VisualStudio->Test->Test Explorer. Now you should see a list of TuneUpTests.
 - Click the target test to run or run them all.
+
+### How to publish a new version
+We currently can't use the release PR option when making releases on mirrored respories. There is a propsed follow-up improvment filed that would allow CILibrary to create a PR against the public repository instead (DYN-8724). But until that is done, our release process will be:
+
+- Create a release branch on the internal respository
+- Build the branch to publish
+- Manually create a PR on the public repsoitory with the changes introduced by the release branch (the updated version number in the pipeline file). 
+- Review and merge this PR
+- Delete the release branch on the internal respository

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,6 +1,5 @@
 version: 2.0.4
 pipeline_os: windows
-create_pr_release_to_master: true
 
 env:
   - GITHUB_ACCESS_TOKEN_ID: github_access_token_acsbuildguy
@@ -47,6 +46,5 @@ deployment:
     publish_to_artifactory: false
     publish_to_package_manager: true
     use_dev_pm: false
-    allow_branches: ".*"
     outputs:
       - TuneUp.zip


### PR DESCRIPTION
We can't use the release PR option when making releases on mirrored repositories.

I have created a follow-up improvement that would allow CILibrary to create a PR against the public repository instead (DYN-8724). But until that is done, our release process will be:

* Create a release branch on the internal repository
* Build the branch to publish
* Manually create a PR on the public repository with the changes introduced by the release branch (the only thing changed is the version number in the pipeline file).
* Review and merge this PR
* Delete the release branch on the internal repository

@AlexisErazoGlobant
