### PR TITLE
Set DataGrid to read-only in TuneUpWindow.xaml

### DIFF
--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -41,6 +41,7 @@
             <!--  DataGrid style  -->
             <Style x:Key="DataGridStyleTuneUpCombined" TargetType="{x:Type DataGrid}">
                 <Setter Property="AutoGenerateColumns" Value="False" />
+                <Setter Property="IsReadOnly" Value="True" />
                 <Setter Property="CanUserAddRows" Value="False" />
                 <Setter Property="CanUserResizeColumns" Value="False" />
                 <Setter Property="CanUserSortColumns" Value="True" />


### PR DESCRIPTION
### Purpose
PR in response to [DYN-8158] (https://jira.autodesk.com/browse/DYN-8158).

This update ensures that the TuneUp tables are fully read-only, preventing users from editing.

![Gif](https://github.com/user-attachments/assets/fc14607a-9b32-4e1a-9ffd-9c7fb393f04d)

### Declarations

Check these if you believe they are true

- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.


### Release Notes

Added IsReadOnly="True" to the DataGridStyleTuneUpCombined style to prevent users from editing data directly in the DataGrid.

### Reviewers
@zeusongit
### 
FYIs
@dnenov