### PR TITLE
DYN-8158: TuneUp extension table cells should not be editable

### DIFF
--- a/TuneUp/Properties/AssemblyInfo.cs
+++ b/TuneUp/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.5")]
-[assembly: AssemblyFileVersion("2.0.5")]
+[assembly: AssemblyVersion("2.0.6")]
+[assembly: AssemblyFileVersion("2.0.6")]

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -598,7 +598,7 @@
                               Loaded="ScrollViewer_Loaded">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
-                            <DataGridTextColumn Width="40" Binding="{Binding Converter={StaticResource ExecutionOrderNumberConverter}}">
+                            <DataGridTextColumn Width="40" Binding="{Binding Converter={StaticResource ExecutionOrderNumberConverter}}" IsReadOnly="True">
                                 <DataGridTextColumn.ElementStyle>
                                     <Style BasedOn="{StaticResource ExecutionOrderTextBlockStyle}" TargetType="TextBlock">
                                         <Setter Property="Text" Value="{Binding ExecutionOrderNumber}" />
@@ -662,7 +662,7 @@
                               Loaded="ScrollViewer_Loaded">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
-                            <DataGridTextColumn Width="40" />
+                            <DataGridTextColumn Width="40" IsReadOnly="True"/>
                             <!--  Node Name  -->
                             <DataGridTemplateColumn Width="*">
                                 <DataGridTemplateColumn.CellTemplate>
@@ -670,7 +670,7 @@
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
                             <!--  Execution Time  -->
-                            <DataGridTextColumn Width="145" />
+                            <DataGridTextColumn Width="145" IsReadOnly="True"/>
                         </DataGrid.Columns>
                     </DataGrid>
                 </StackPanel>

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -517,7 +517,7 @@
                               Loaded="ScrollViewer_Loaded">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
-                            <DataGridTextColumn Width="40" Header="{x:Static resx:Resources.Header_ExecutionOrder}">
+                            <DataGridTextColumn Width="40" Header="{x:Static resx:Resources.Header_ExecutionOrder}" IsReadOnly="True">
                                 <DataGridTextColumn.HeaderTemplate>
                                     <DataTemplate>
                                         <TextBlock Text="{x:Static resx:Resources.Header_ExecutionOrder}">

--- a/TuneUp/TuneUpWindow.xaml
+++ b/TuneUp/TuneUpWindow.xaml
@@ -62,6 +62,7 @@
                 <Setter Property="SnapsToDevicePixels" Value="True" />
                 <Setter Property="Background" Value="{StaticResource ExtensionBackgroundColor}" />
                 <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="IsReadOnly" Value="True" />
             </Style>
             <!--  DataGridColumnHeader style  -->
             <Style x:Key="ColumnHeaderStyleTuneUp" TargetType="DataGridColumnHeader">
@@ -517,7 +518,7 @@
                               Loaded="ScrollViewer_Loaded">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
-                            <DataGridTextColumn Width="40" Header="{x:Static resx:Resources.Header_ExecutionOrder}" IsReadOnly="True">
+                            <DataGridTextColumn Width="40" Header="{x:Static resx:Resources.Header_ExecutionOrder}">
                                 <DataGridTextColumn.HeaderTemplate>
                                     <DataTemplate>
                                         <TextBlock Text="{x:Static resx:Resources.Header_ExecutionOrder}">
@@ -598,7 +599,7 @@
                               Loaded="ScrollViewer_Loaded">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
-                            <DataGridTextColumn Width="40" Binding="{Binding Converter={StaticResource ExecutionOrderNumberConverter}}" IsReadOnly="True">
+                            <DataGridTextColumn Width="40" Binding="{Binding Converter={StaticResource ExecutionOrderNumberConverter}}" >
                                 <DataGridTextColumn.ElementStyle>
                                     <Style BasedOn="{StaticResource ExecutionOrderTextBlockStyle}" TargetType="TextBlock">
                                         <Setter Property="Text" Value="{Binding ExecutionOrderNumber}" />
@@ -662,7 +663,7 @@
                               Loaded="ScrollViewer_Loaded">
                         <DataGrid.Columns>
                             <!--  Execution Order  -->
-                            <DataGridTextColumn Width="40" IsReadOnly="True"/>
+                            <DataGridTextColumn Width="40"/>
                             <!--  Node Name  -->
                             <DataGridTemplateColumn Width="*">
                                 <DataGridTemplateColumn.CellTemplate>

--- a/TuneUp/manifests/pkg.json
+++ b/TuneUp/manifests/pkg.json
@@ -2,7 +2,7 @@
   "license": "MIT",
   "file_hash": null,
   "name": "TuneUp",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "On Dynamo 2.5–2.19 (.NET 4.8), use TuneUp versions up to 1.0.7.\r\nOn Dynamo 3.0+ (.NET 8), use TuneUp version 2.0.0+.\r\n\r\nTuneUp is a view extension for analyzing the performance of Dynamo graphs. TuneUp allows you to see overall graph execution time, per-node execution time, execution time of groups, and other helpful information. With TuneUp, you can rerun all nodes, including ones that are normally skipped for optimization/caching during repeated runs of a graph. This enables you to compare the actual execution times between multiple runs. Read more here: https://dynamobim.org/tuneup-extension-explore-your-node-and-graph-execution-times/. \r\n\r\nKnown issues:\r\n1. TuneUp does not work in a custom node workspace.\r\n2. TuneUp binaries are not semantically versioned and are not intended to be built on top of as an API. Do not treat these binaries like DynamoCore.",
   "group": "",
   "keywords": [


### PR DESCRIPTION
Small PR to address [DYN-8158](https://jira.autodesk.com/browse/DYN-8158) by making TuneUp table cells in the execution-order (#) column non-editable.

Users could previously double-click and type arbitrary values in this column, even though it should only display execution order. This change sets those cells to read-only across the TuneUp tables, preserving the intended behavior and preventing accidental edits.

Before:
![DYN-8158-Before](https://github.com/user-attachments/assets/a6e9bf80-ae5d-4f40-919b-909714da9f61)


After:
![DYN-8158-After](https://github.com/user-attachments/assets/75f5c2cc-6d0b-4562-a3cc-27f4c643e30a)


@zeusongit
@johnpierson
@dnenov